### PR TITLE
Window manager changes

### DIFF
--- a/NiceHashMiner/Configs/Data/DeviceBenchmarkConfig.cs
+++ b/NiceHashMiner/Configs/Data/DeviceBenchmarkConfig.cs
@@ -8,6 +8,10 @@ namespace NiceHashMiner.Configs.Data {
     public class DeviceBenchmarkConfig {
         public string DeviceUUID = "";
         public string DeviceName = "";
+        //Window location and monitor settings
+        public int WindowMonitor = -1;
+        public int WindowX = -1;
+        public int WindowY = -1;
         //public int TimeLimit { get; set; }
         public List<AlgorithmConfig> AlgorithmSettings = new List<AlgorithmConfig>();
     }

--- a/NiceHashMiner/Configs/Data/GeneralConfig.cs
+++ b/NiceHashMiner/Configs/Data/GeneralConfig.cs
@@ -21,6 +21,9 @@ namespace NiceHashMiner.Configs.Data {
         public bool HideMiningWindows = false;
         public bool MinimizeToTray = false;
         public bool MinimizeMiningWindows = false;
+        public int StartupWindowMonitor = -1;
+        public int StartupWindowX = -1;
+        public int StartupWindowY = -1;
         //public int LessThreads;
         public CPUExtensionType ForceCPUExtension = CPUExtensionType.Automatic;
 

--- a/NiceHashMiner/Devices/ComputeDevice/ComputeDevice.cs
+++ b/NiceHashMiner/Devices/ComputeDevice/ComputeDevice.cs
@@ -29,6 +29,10 @@ namespace NiceHashMiner.Devices
         readonly public DeviceType DeviceType;
         // UUID now used for saving
         public string UUID { get; protected set; }
+        // Initial window coordinates and monitor info
+        public int WindowMonitor { get; protected set; } = -1;
+        public int WindowX { get; protected set; } = -1;
+        public int WindowY { get; protected set; } = -1;
 
         // used for Claymore indexing
         public int BusID { get; protected set; } = -1;
@@ -192,6 +196,9 @@ namespace NiceHashMiner.Devices
         }
         public void SetAlgorithmDeviceConfig(DeviceBenchmarkConfig config) {
             if (config != null && config.DeviceUUID == UUID && config.AlgorithmSettings != null) {
+                WindowMonitor = config.WindowMonitor;
+                WindowX = config.WindowX;
+                WindowY = config.WindowY;
                 this.AlgorithmSettings = GroupAlgorithms.CreateForDeviceList(this);
                 foreach (var conf in config.AlgorithmSettings) {
                     var setAlgo = GetAlgorithm(conf.MinerBaseType, conf.NiceHashID, conf.SecondaryNiceHashID);
@@ -217,6 +224,9 @@ namespace NiceHashMiner.Devices
             DeviceBenchmarkConfig ret = new DeviceBenchmarkConfig();
             ret.DeviceName = this.Name;
             ret.DeviceUUID = this.UUID;
+            ret.WindowMonitor = this.WindowMonitor;
+            ret.WindowX = this.WindowX;
+            ret.WindowY = this.WindowY;
             // init algo settings
             foreach (var algo in this.AlgorithmSettings) {
                 // create/setup

--- a/NiceHashMiner/Forms/Form_Main.cs
+++ b/NiceHashMiner/Forms/Form_Main.cs
@@ -142,6 +142,35 @@ namespace NiceHashMiner
         }
 
         private void InitMainConfigGUIData() {
+            
+            if ((ConfigManager.GeneralConfig.StartupWindowX > -1) || (ConfigManager.GeneralConfig.StartupWindowY > -1))
+            {
+                // If startup window coordinates are defined, position the window
+                int windowX = ConfigManager.GeneralConfig.StartupWindowX;
+                int windowY = ConfigManager.GeneralConfig.StartupWindowY;
+                if (windowX < 0) windowX = this.Location.X;
+                if (windowY < 0) windowY = this.Location.Y;
+                this.StartPosition = FormStartPosition.Manual;
+                this.Location = WindowManager.GetMonitorCorrectedFormPoints(ConfigManager.GeneralConfig.StartupWindowMonitor,
+                    windowX, windowY);
+                if (ConfigManager.GeneralConfig.DebugConsole)
+                {
+                    WindowManager.MoveConsoleWindow(Process.GetCurrentProcess().Id, 
+                        ConfigManager.GeneralConfig.StartupWindowMonitor, windowX, windowY + this.Height);
+                }
+            }
+            else if (ConfigManager.GeneralConfig.StartupWindowMonitor > -1)
+            {
+                // If only startup monitor is defined, center the window on the target monitor
+                this.StartPosition = FormStartPosition.Manual;
+                this.Location = WindowManager.GetCenteredOnMonitorFormPoints(ConfigManager.GeneralConfig.StartupWindowMonitor,
+                    this.Width, this.Height);
+                if (ConfigManager.GeneralConfig.DebugConsole)
+                {
+                    WindowManager.MoveConsoleWindow(Process.GetCurrentProcess().Id,
+                        ConfigManager.GeneralConfig.StartupWindowMonitor, this.Location.X, this.Location.Y + this.Height);
+                }
+            }
             if (ConfigManager.GeneralConfig.ServiceLocation >= 0 && ConfigManager.GeneralConfig.ServiceLocation < Globals.MiningLocation.Length)
                 comboBoxLocation.SelectedIndex = ConfigManager.GeneralConfig.ServiceLocation;
             else

--- a/NiceHashMiner/Forms/Form_Main.cs
+++ b/NiceHashMiner/Forms/Form_Main.cs
@@ -142,33 +142,37 @@ namespace NiceHashMiner
         }
 
         private void InitMainConfigGUIData() {
-            
-            if ((ConfigManager.GeneralConfig.StartupWindowX > -1) || (ConfigManager.GeneralConfig.StartupWindowY > -1))
+
+            // Only run this once
+            if (this.StartPosition != FormStartPosition.Manual)
             {
-                // If startup window coordinates are defined, position the window
-                int windowX = ConfigManager.GeneralConfig.StartupWindowX;
-                int windowY = ConfigManager.GeneralConfig.StartupWindowY;
-                if (windowX < 0) windowX = this.Location.X;
-                if (windowY < 0) windowY = this.Location.Y;
-                this.StartPosition = FormStartPosition.Manual;
-                this.Location = WindowManager.GetMonitorCorrectedFormPoints(ConfigManager.GeneralConfig.StartupWindowMonitor,
-                    windowX, windowY);
-                if (ConfigManager.GeneralConfig.DebugConsole)
+                if ((ConfigManager.GeneralConfig.StartupWindowX > -1) || (ConfigManager.GeneralConfig.StartupWindowY > -1))
                 {
-                    WindowManager.MoveConsoleWindow(Process.GetCurrentProcess().Id, 
-                        ConfigManager.GeneralConfig.StartupWindowMonitor, windowX, windowY + this.Height);
+                    // If startup window coordinates are defined, position the window
+                    int windowX = ConfigManager.GeneralConfig.StartupWindowX;
+                    int windowY = ConfigManager.GeneralConfig.StartupWindowY;
+                    if (windowX < 0) windowX = this.Location.X;
+                    if (windowY < 0) windowY = this.Location.Y;
+                    this.StartPosition = FormStartPosition.Manual;
+                    this.Location = WindowManager.GetMonitorCorrectedFormPoints(ConfigManager.GeneralConfig.StartupWindowMonitor,
+                        windowX, windowY);
+                    if (ConfigManager.GeneralConfig.DebugConsole)
+                    {
+                        WindowManager.MoveConsoleWindow(Process.GetCurrentProcess().Id,
+                            ConfigManager.GeneralConfig.StartupWindowMonitor, windowX, windowY + this.Height);
+                    }
                 }
-            }
-            else if (ConfigManager.GeneralConfig.StartupWindowMonitor > -1)
-            {
-                // If only startup monitor is defined, center the window on the target monitor
-                this.StartPosition = FormStartPosition.Manual;
-                this.Location = WindowManager.GetCenteredOnMonitorFormPoints(ConfigManager.GeneralConfig.StartupWindowMonitor,
-                    this.Width, this.Height);
-                if (ConfigManager.GeneralConfig.DebugConsole)
+                else if (ConfigManager.GeneralConfig.StartupWindowMonitor > -1)
                 {
-                    WindowManager.MoveConsoleWindow(Process.GetCurrentProcess().Id,
-                        ConfigManager.GeneralConfig.StartupWindowMonitor, this.Location.X, this.Location.Y + this.Height);
+                    // If only startup monitor is defined, center the window on the target monitor
+                    this.StartPosition = FormStartPosition.Manual;
+                    this.Location = WindowManager.GetCenteredOnMonitorFormPoints(ConfigManager.GeneralConfig.StartupWindowMonitor,
+                        this.Width, this.Height);
+                    if (ConfigManager.GeneralConfig.DebugConsole)
+                    {
+                        WindowManager.MoveConsoleWindow(Process.GetCurrentProcess().Id,
+                            ConfigManager.GeneralConfig.StartupWindowMonitor, this.Location.X, this.Location.Y + this.Height);
+                    }
                 }
             }
             if (ConfigManager.GeneralConfig.ServiceLocation >= 0 && ConfigManager.GeneralConfig.ServiceLocation < Globals.MiningLocation.Length)

--- a/NiceHashMiner/Miners/Miner.cs
+++ b/NiceHashMiner/Miners/Miner.cs
@@ -755,6 +755,8 @@ namespace NiceHashMiner
 
             try
             {
+                // Get handle of current foreground window before starting mining process
+                IntPtr currentForegroundWindow = Utils.WindowManager.GetForegroundWindow();
                 if (P.Start()) {
                     IsRunning = true;
 
@@ -766,6 +768,14 @@ namespace NiceHashMiner
                     Helpers.ConsolePrint(MinerTAG(), "Starting miner " + ProcessTag() + " " + LastCommandLine);
 
                     StartCoolDownTimerChecker();
+                    // If there are coordinates configured for the mining device, move the window
+                    if (MiningSetup.MiningPairs[0].Device.WindowX > -1 || MiningSetup.MiningPairs[0].Device.WindowY > -1)
+                    {
+                        Utils.WindowManager.MoveConsoleWindow(P.Id, MiningSetup.MiningPairs[0].Device.WindowMonitor,
+                            MiningSetup.MiningPairs[0].Device.WindowX, MiningSetup.MiningPairs[0].Device.WindowY);
+                        // Bring focus and top most z-order to previous foreground window
+                        Utils.WindowManager.BringWindowToTop(currentForegroundWindow);
+                    }
 
                     return P;
                 } else {

--- a/NiceHashMiner/NiceHashMinerLegacy.csproj
+++ b/NiceHashMiner/NiceHashMinerLegacy.csproj
@@ -304,6 +304,7 @@
     <Compile Include="Utils\MinersDownloader.cs" />
     <Compile Include="Utils\MinersDownloadManager.cs" />
     <Compile Include="Utils\MinersExistanceChecker.cs" />
+    <Compile Include="Utils\WindowManager.cs" />
     <EmbeddedResource Include="Forms\Components\AlgorithmsListView.resx">
       <DependentUpon>AlgorithmsListView.cs</DependentUpon>
       <SubType>Designer</SubType>

--- a/NiceHashMiner/PInvoke/NiceHashProcess.cs
+++ b/NiceHashMiner/PInvoke/NiceHashProcess.cs
@@ -13,6 +13,7 @@ namespace NiceHashMiner
         private const uint NORMAL_PRIORITY_CLASS = 0x0020;
         private const uint CREATE_NO_WINDOW = 0x08000000;
         private const int STARTF_USESHOWWINDOW = 0x00000001;
+        private const short SW_SHOWNOACTIVATE = 4;
         private const short SW_SHOWMINNOACTIVE = 7;
         private const uint INFINITE = 0xFFFFFFFF;
         private const uint STILL_ACTIVE = 259;
@@ -159,6 +160,8 @@ namespace NiceHashMiner
                 sflags = CREATE_NEW_CONSOLE;
             }
             else {
+                sInfo.dwFlags = STARTF_USESHOWWINDOW;
+                sInfo.wShowWindow = SW_SHOWNOACTIVATE;
                 sflags = CREATE_NEW_CONSOLE;
             }
 

--- a/NiceHashMiner/Utils/WindowManager.cs
+++ b/NiceHashMiner/Utils/WindowManager.cs
@@ -1,0 +1,122 @@
+﻿using System;
+using System.Linq;
+using System.Text;
+using System.Diagnostics;
+using System.Drawing;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Windows.Forms;
+
+namespace NiceHashMiner.Utils
+{
+    class WindowManager
+    {
+        // Move window to specified coordinates
+        [DllImport("user32.dll", SetLastError = true)]
+        public static extern bool MoveWindow(IntPtr hWnd, int X, int Y, int nWidth, int nHeight, bool bRepaint);
+
+        // Find window location and dimensions
+        [DllImport("user32.dll", SetLastError = true)]
+        public static extern bool GetWindowRect(IntPtr hWnd, out RECT lpRect);
+
+        [DllImport("user32.dll")]
+        static extern int GetWindowText(IntPtr hWnd, StringBuilder text, int count);
+
+        [DllImport("user32.dll")]
+        public static extern IntPtr GetForegroundWindow();
+
+        [DllImport("user32.dll", SetLastError = true)]
+        public static extern bool BringWindowToTop(IntPtr hWnd);
+
+        [DllImport("USER32.DLL")]
+        public static extern bool SetForegroundWindow(IntPtr hWnd);
+
+        [System.Runtime.InteropServices.DllImport("User32.dll")]
+        public static extern bool ShowWindow(IntPtr handle, int nCmdShow);
+
+        // Rectangle structure used by GetWindowRect pinvoke call
+        [StructLayout(LayoutKind.Sequential)]
+        public struct RECT
+        {
+            public int Left;
+            public int Top;
+            public int Right;
+            public int Bottom;
+        }
+
+        public static Point GetMonitorCorrectedFormPoints(int monitorNum, int windowX, int windowY)
+        {
+            Point retVal = new Point(windowX, windowX);
+            if (monitorNum > -1)
+            {
+                Screen[] myScreens = Screen.AllScreens;
+                if (myScreens.GetLength(0) >= monitorNum)
+                {
+                    retVal = new Point(Screen.AllScreens[monitorNum].WorkingArea.X + windowX,
+                        Screen.AllScreens[monitorNum].WorkingArea.Y + windowY);
+                }
+            }
+            return retVal;
+        }
+
+        public static Point GetCenteredOnMonitorFormPoints(int monitorNum, int windowWidth, int windowHeight)
+        {
+            Point retVal = new Point(0, 0);
+            if (monitorNum < 0) monitorNum = 0;
+
+            Screen[] myScreens = Screen.AllScreens;
+            if (myScreens.GetLength(0) >= monitorNum)
+            {
+                int StartPosX = Screen.AllScreens[monitorNum].WorkingArea.X;
+                StartPosX = StartPosX + (Screen.AllScreens[monitorNum].WorkingArea.Width / 2);
+                StartPosX = StartPosX - (windowWidth / 2);
+                int StartPosY = Screen.AllScreens[monitorNum].WorkingArea.Y;
+                StartPosY = StartPosY + (Screen.AllScreens[monitorNum].WorkingArea.Height / 2);
+                StartPosY = StartPosY - (windowHeight / 2);
+                retVal = new Point(StartPosX, StartPosY);
+            }
+            return retVal;
+        }
+
+        public static void MoveConsoleWindow(int processId, int monitorNum, int xCoord, int yCoord)
+        {
+            Process consoleProcess = Process.GetProcessById(processId);
+            if (consoleProcess != null)
+            {
+                RECT rect = new RECT();
+                int chkCtr = 0;
+                do
+                {
+                    // Get current console window location and dimensions, all zeros until window is initialized. Loop is 2500ms
+                    GetWindowRect(consoleProcess.MainWindowHandle, out rect);
+                    if (!(rect.Left == 0 && rect.Right == 0 && rect.Top == 0 && rect.Bottom == 0)) break;
+                    Thread.Sleep(50);
+                    chkCtr++;
+                } while (chkCtr < 50);
+                // If we couldn't get reliable coordinates it may have not started or crashed, don't continue
+                if (rect.Left == 0 && rect.Right == 0 && rect.Top == 0 && rect.Bottom == 0) return;
+
+                // If the monitor number is <= -1, we assume the primary monitor is used
+                if (monitorNum < 0) monitorNum = 0;
+                // If the x or y coordinates are <= -1, then we inherit the window's current x/y coordinates
+                if (xCoord < 0) xCoord = rect.Left;
+                if (yCoord < 0) yCoord = rect.Top;
+
+                Screen[] myScreens = Screen.AllScreens;
+                if (myScreens.Count() > monitorNum)
+                {
+                    // Check coordinates against screen boundaries, correct if needed
+                    if (xCoord + (rect.Right - rect.Left) > myScreens[monitorNum].Bounds.Width)
+                        xCoord = xCoord - ((xCoord + (rect.Right - rect.Left)) - myScreens[monitorNum].Bounds.Width);
+                    if (yCoord + (rect.Bottom - rect.Top) > myScreens[monitorNum].Bounds.Height)
+                        yCoord = yCoord - ((yCoord + (rect.Bottom - rect.Top)) - myScreens[monitorNum].Bounds.Height);
+                    // Apply config values as offset on screen boundaries
+                    xCoord = xCoord + myScreens[monitorNum].Bounds.X;
+                    yCoord = yCoord + myScreens[monitorNum].Bounds.Y;
+                }
+                // Move window to specified coordinates
+                MoveWindow(consoleProcess.MainWindowHandle, xCoord, yCoord, (rect.Right - rect.Left), (rect.Bottom - rect.Top), true);
+            }
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -91,6 +91,9 @@ WorkerName | text | To identify the computer on NiceHash web UI.
 ServiceLocation | number | Used to select the location of the mining server.
 HideMiningWindows | true or false | When set to true, sgminer, ccminer and cpuminer console windows will be hidden.
 MinimizeToTray | true or false | When set to true, NiceHashMinerLegacy will minimize to the system tray.
+StartupWindowMonitor | number | When set to 0 or above, NiceHashMinerLegacy will move the main interface to the specified monitor. If set to -1 the primary monitor will be used.
+StartupWindowX | number | When set to 0 or above, NiceHashMinerLegacy will move the main interface to the specified x coordinate. (On the monitor specified in StartupWindowMonitor)
+StartupWindowY | number | When set to 0 or above, NiceHashMinerLegacy will move the main interface to the specified y coordinate. (On the monitor specified in StartupWindowMonitor)
 ForceCPUExtension | 0, 1, 2, 3 or 4 | Force certain CPU extension miner. 0 is automatic, 1 for AVX2, 2 for AVX, 3 for AES and  4 for SSE2.
 SwitchMinSecondsFixed | number | Fixed part of minimal time (in seconds) before miner switches algorithm. Total time is SwitchMinSecondsFixed + SwitchMinSecondsDynamic.
 SwitchMinSecondsDynamic | number | Random part of minimal time (in seconds) before miner switches algorithm. Total time is SwitchMinSecondsFixed + SwitchMinSecondsDynamic. Random part is used to prevent all world-wide NiceHash Miner Legacy users to have the exact same switching pattern.
@@ -129,6 +132,9 @@ Parameter | Range | Description
 -----------------|----------|-------------------
 DeviceUUID | text | Used for unique identification purposes in the config file (**DO NOT EDIT**)
 DeviceName | text | Used for identification purposes in the config file (**DO NOT EDIT**)
+WindowMonitor | number | When set to 0 or above, NiceHashMinerLegacy will move the mining console to the specified monitor. If set to -1 the primary monitor will be used.
+WindowX | number | When set to 0 or above, NiceHashMinerLegacy will move the mining console to the specified x coordinate. (On the monitor specified in WindowMonitor)
+WindowY | number | When set to 0 or above, NiceHashMinerLegacy will move the mining console to the specified y coordinate. (On the monitor specified in WindowMonitor)
 AlgorithmSettings | dictionary {key: text, value: Algorithm } | Key value paired dictionary with avaliable device algorithms settings. Keys should not be edited only Algorithm data.
 AlgorithmSettings\Algorithm\NiceHashID | number | Algorithm ID (**DO NOT EDIT**)
 AlgorithmSettings\Algorithm\MinerName | text | specific miner name setting (**DO NOT EDIT**)


### PR DESCRIPTION
A window manager class has been added and configuration entries to the general config and compute device configs to allow initial placement of windows.  Multiple monitors are supported as well.

No changes made to the GUI to make setting these values, you'll need to edit the general config and benchmark config JSON files.

Master pull request notes for maintainers:
These changes allow a user to have mining worker windows always start up in a particular location on a specified monitor.  By default the settings are all -1 which disables this functionality to prevent unexpected behavior.  Initial mining windows also set to not steal foreground focus regardless of these settings. If the debug console is active, it's snapped to the bottom of the main window when it opens. For users that use the PC while mining, these settings will keep windows where they belong and keep them from stealing focus while they're working in other windows.  Modifications to the GUI can be made after these changes are determined to function well and without interference.