### PR TITLE
Prospector fixes

### DIFF
--- a/NiceHashMiner/Miners/Prospector.cs
+++ b/NiceHashMiner/Miners/Prospector.cs
@@ -145,7 +145,9 @@ namespace NiceHashMiner.Miners
             {
                 // fallback
                 Helpers.ConsolePrint(MinerTag(), "Failed to get platforms, falling back");
-                if (ComputeDeviceManager.Avaliable.HasNvidia && type != DeviceType.NVIDIA)
+                if (ComputeDeviceManager.Avaliable.HasNvidia && type == DeviceType.NVIDIA)
+                    platform = 1;
+                if (ComputeDeviceManager.Avaliable.HasAmd && type == DeviceType.AMD)
                     platform = 1;
             }
             return $"{platform}-{id}";
@@ -208,7 +210,21 @@ namespace NiceHashMiner.Miners
                 }
                 if (File.Exists(dirInfo + latestLogFile))
                 {
-                    var lines = File.ReadAllLines(dirInfo + latestLogFile);
+                    var lines = new string[] { };
+                    int retries = 10;
+                    while (true) {
+                        try {
+                            lines = File.ReadAllLines(dirInfo + latestLogFile);
+                            break;
+                        } catch (System.IO.IOException e) {
+                            if (retries-- > 0) {
+                                Helpers.ConsolePrint(MinerTag(), String.Format("Retrying ({0})", e.GetType().ToString()));
+                                Thread.Sleep(1 * 1000); // 1 second
+                                continue;
+                            }
+                            throw e;
+                        }
+                    }
                     foreach (var line in lines)
                     {
                         if (line == null) continue;

--- a/NiceHashMiner/Miners/Prospector.cs
+++ b/NiceHashMiner/Miners/Prospector.cs
@@ -438,24 +438,25 @@ namespace NiceHashMiner.Miners
                 var sessionStart = Convert.ToDateTime(session.start);
                 if (sessionStart < startTime)
                 {
-                    throw new Exception("Session not recorded!");
+                    Helpers.ConsolePrint(MinerTag(), "Session not recorded!");
                 }
-
-                var hashrates = _database.QuerySpeedsForSession(session.id);
-
-                double speed = 0;
-                var speedRead = 0;
-                foreach (var hashrate in hashrates)
+                else
                 {
-                    if (hashrate.coin == MiningSetup.MinerName && hashrate.rate > 0)
+                    var hashrates = _database.QuerySpeedsForSession(session.id);
+
+                    double speed = 0;
+                    var speedRead = 0;
+                    foreach (var hashrate in hashrates)
                     {
-                        speed += hashrate.rate;
-                        speedRead++;
+                        if (hashrate.coin == MiningSetup.MinerName && hashrate.rate > 0)
+                        {
+                            speed += hashrate.rate;
+                            speedRead++;
+                        }
                     }
+
+                    BenchmarkAlgorithm.BenchmarkSpeed = (speed / speedRead) * (1 - DevFee);
                 }
-
-                BenchmarkAlgorithm.BenchmarkSpeed = (speed / speedRead) * (1 - DevFee);
-
                 BenchmarkThreadRoutineFinish();
             }
         }

--- a/NiceHashMiner/Miners/prospector.cs
+++ b/NiceHashMiner/Miners/prospector.cs
@@ -145,7 +145,9 @@ namespace NiceHashMiner.Miners
             {
                 // fallback
                 Helpers.ConsolePrint(MinerTag(), "Failed to get platforms, falling back");
-                if (ComputeDeviceManager.Avaliable.HasNvidia && type != DeviceType.NVIDIA)
+                if (ComputeDeviceManager.Avaliable.HasNvidia && type == DeviceType.NVIDIA)
+                    platform = 1;
+                if (ComputeDeviceManager.Avaliable.HasAmd && type == DeviceType.AMD)
                     platform = 1;
             }
             return $"{platform}-{id}";
@@ -208,7 +210,21 @@ namespace NiceHashMiner.Miners
                 }
                 if (File.Exists(dirInfo + latestLogFile))
                 {
-                    var lines = File.ReadAllLines(dirInfo + latestLogFile);
+                    var lines = new string[] { };
+                    int retries = 10;
+                    while (true) {
+                        try {
+                            lines = File.ReadAllLines(dirInfo + latestLogFile);
+                            break;
+                        } catch (System.IO.IOException e) {
+                            if (retries-- > 0) {
+                                Helpers.ConsolePrint(MinerTag(), String.Format("Retrying ({0})", e.GetType().ToString()));
+                                Thread.Sleep(1 * 1000); // 1 second
+                                continue;
+                            }
+                            throw e;
+                        }
+                    }
                     foreach (var line in lines)
                     {
                         if (line == null) continue;

--- a/NiceHashMiner/Miners/prospector.cs
+++ b/NiceHashMiner/Miners/prospector.cs
@@ -438,24 +438,25 @@ namespace NiceHashMiner.Miners
                 var sessionStart = Convert.ToDateTime(session.start);
                 if (sessionStart < startTime)
                 {
-                    throw new Exception("Session not recorded!");
+                    Helpers.ConsolePrint(MinerTag(), "Session not recorded!");
                 }
-
-                var hashrates = _database.QuerySpeedsForSession(session.id);
-
-                double speed = 0;
-                var speedRead = 0;
-                foreach (var hashrate in hashrates)
+                else
                 {
-                    if (hashrate.coin == MiningSetup.MinerName && hashrate.rate > 0)
+                    var hashrates = _database.QuerySpeedsForSession(session.id);
+
+                    double speed = 0;
+                    var speedRead = 0;
+                    foreach (var hashrate in hashrates)
                     {
-                        speed += hashrate.rate;
-                        speedRead++;
+                        if (hashrate.coin == MiningSetup.MinerName && hashrate.rate > 0)
+                        {
+                            speed += hashrate.rate;
+                            speedRead++;
+                        }
                     }
+
+                    BenchmarkAlgorithm.BenchmarkSpeed = (speed / speedRead) * (1 - DevFee);
                 }
-
-                BenchmarkAlgorithm.BenchmarkSpeed = (speed / speedRead) * (1 - DevFee);
-
                 BenchmarkThreadRoutineFinish();
             }
         }


### PR DESCRIPTION
We observe the following exception:

[2017-11-20 13:39:00] [INFO] [Prospector-MINER_ID(0)-DEVICE_IDs(0)] System.IO.IOException: The process cannot access the file 'XXX\NiceHashMiner\Debug\bin_3rdparty\prospector\logs\20_11_17 06;38;59' because it is being used by another process.
   at System.IO.__Error.WinIOError(Int32 errorCode, String maybeFullPath)
   at System.IO.FileStream.Init(String path, FileMode mode, FileAccess access, Int32 rights, Boolean useRights, FileShare share, Int32 bufferSize, FileOptions options, SECURITY_ATTRIBUTES secAttrs, String msgPath, Boolean bFromProxy, Boolean useLongPath, Boolean checkHost)
   at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, FileOptions options, String msgPath, Boolean bFromProxy, Boolean useLongPath, Boolean checkHost)
   at System.IO.StreamReader..ctor(String path, Encoding encoding, Boolean detectEncodingFromByteOrderMarks, Int32 bufferSize, Boolean checkHost)
   at System.IO.StreamReader..ctor(String path, Encoding encoding)
   at System.IO.File.InternalReadAllLines(String path, Encoding encoding)
   at NiceHashMiner.Miners.Prospector.InitPlatforms() in XXX\NiceHashMiner\Miners\prospector.cs:line 176

The root cause is two-fold:
- the condition in deviceIDString() fallback branch does not seem to be correct (should be "type ==" instead of "type !="), also the fallback for AMD is missing
- WaitForExit() (even if returned "true") does not guarantee that all the process resources are freed (see https://social.msdn.microsoft.com/Forums/vstudio/en-US/5e3e8f7c-3ff8-40f0-b797-8c4bc25253dd/processwaitforexit-doesnt-actually-wait-for-the-process-to-completely-exit)

As a result broken config for prospector is written (having "[gpus.0-0]" instead of "[gpus-1-0]").

Also, there is an additional commit to fix unhandled exception in the BenchmarkThreadRoutine()