### PR TITLE
XMR-Stak (Unified) | Not finished yet

### DIFF
--- a/NiceHashMiner/Miners/XmrStak/XmrStackCPUMiner.cs
+++ b/NiceHashMiner/Miners/XmrStak/XmrStackCPUMiner.cs
@@ -14,24 +14,67 @@ using System.Threading.Tasks;
 
 namespace NiceHashMiner.Miners {
 
-    public class XmrStackCPUMinerConfig : XmrStakConfig
+    public class XmrStackMainMinerConfig : XmrStakConfig
     {
-        public XmrStackCPUMinerConfig(int numberOfthreads, string poolAddr, string wallet, int port)
+        public XmrStackMainMinerConfig(string poolAddr, string wallet, int port)
             : base(poolAddr, wallet, port) {
+        }
+
+        /*
+         * use_slow_memory defines our behaviour with regards to large pages. There are three possible options here:
+         * always  - Don't even try to use large pages. Always use slow memory.
+         * warn    - We will try to use large pages, but fall back to slow memory if that fails.
+         * no_mlck - This option is only relevant on Linux, where we can use large pages without locking memory.
+         *           It will never use slow memory, but it won't attempt to mlock
+         * never   - If we fail to allocate large pages we will print an error and exit.
+         */
+        public string use_slow_memory = "warn";
+
+        /*
+         * NiceHash mode
+         * nicehash_nonce - Limit the noce to 3 bytes as required by nicehash. This cuts all the safety margins, and
+         *                  if a block isn't found within 30 minutes then you might run into nonce collisions. Number
+         *                  of threads in this mode is hard-limited to 32.
+         */
+        public readonly bool nicehash_nonce = true; // 
+
+        /*
+         * Manual hardware AES override
+         *
+         * Some VMs don't report AES capability correctly. You can set this value to true to enforce hardware AES or 
+         * to false to force disable AES or null to let the miner decide if AES is used.
+         * 
+         * WARNING: setting this to true on a CPU that doesn't support hardware AES will crash the miner.
+         */
+        public readonly bool? aes_override = null;
+    }
+    public class XmrStackCPUMinerConfig
+    {
+        public XmrStackCPUMinerConfig(int numberOfthreads)
+        {
             cpu_thread_num = numberOfthreads;
         }
 
-        public void Inti_cpu_threads_conf(bool low_power_mode, bool no_prefetch, bool affine_to_cpu, bool isHyperThreading) {
+        public void Inti_cpu_threads_conf(bool low_power_mode, bool no_prefetch, bool affine_to_cpu, bool isHyperThreading)
+        {
             cpu_threads_conf = new List<JObject>();
-            if (isHyperThreading) {
-                for (int i_cpu = 0; i_cpu < cpu_thread_num; ++i_cpu) {
+            if (isHyperThreading)
+            {
+                for (int i_cpu = 0; i_cpu < cpu_thread_num; ++i_cpu)
+                {
                     cpu_threads_conf.Add(JObject.FromObject(new { low_power_mode = low_power_mode, no_prefetch = no_prefetch, affine_to_cpu = i_cpu * 2 }));
                 }
-            } else {
-                for (int i_cpu = 0; i_cpu < cpu_thread_num; ++i_cpu) {
-                    if (affine_to_cpu) {
+            }
+            else
+            {
+                for (int i_cpu = 0; i_cpu < cpu_thread_num; ++i_cpu)
+                {
+                    if (affine_to_cpu)
+                    {
                         cpu_threads_conf.Add(JObject.FromObject(new { low_power_mode = low_power_mode, no_prefetch = no_prefetch, affine_to_cpu = i_cpu }));
-                    } else {
+                    }
+                    else
+                    {
                         cpu_threads_conf.Add(JObject.FromObject(new { low_power_mode = low_power_mode, no_prefetch = no_prefetch, affine_to_cpu = false }));
                     }
                 }
@@ -66,66 +109,12 @@ namespace NiceHashMiner.Miners {
         //    { "low_power_mode" : false, "no_prefetch" : false, "affine_to_cpu" : 1 },
         //],
 
-        /*
-         * LARGE PAGE SUPPORT
-         * Lare pages need a properly set up OS. It can be difficult if you are not used to systems administation,
-         * but the performace results are worth the trouble - you will get around 20% boost. Slow memory mode is
-         * meant as a backup, you won't get stellar results there. If you are running into trouble, especially
-         * on Windows, please read the common issues in the README.
-         *
-         * By default we will try to allocate large pages. This means you need to "Run As Administrator" on Windows.
-         * You need to edit your system's group policies to enable locking large pages. Here are the steps from MSDN
-         *
-         * 1. On the Start menu, click Run. In the Open box, type gpedit.msc.
-         * 2. On the Local Group Policy Editor console, expand Computer Configuration, and then expand Windows Settings.
-         * 3. Expand Security Settings, and then expand Local Policies.
-         * 4. Select the User Rights Assignment folder.
-         * 5. The policies will be displayed in the details pane.
-         * 6. In the pane, double-click Lock pages in memory.
-         * 7. In the Local Security Setting – Lock pages in memory dialog box, click Add User or Group.
-         * 8. In the Select Users, Service Accounts, or Groups dialog box, add an account that you will run the miner on
-         * 9. Reboot for change to take effect.
-         *
-         * Windows also tends to fragment memory a lot. If you are running on a system with 4-8GB of RAM you might need
-         * to switch off all the auto-start applications and reboot to have a large enough chunk of contiguous memory.
-         *
-         * On Linux you will need to configure large page support "sudo sysctl -w vm.nr_hugepages=128" and increase your
-         * ulimit -l. To do do this you need to add following lines to /etc/security/limits.conf - "* soft memlock 262144"
-         * and "* hard memlock 262144". You can also do it Windows-style and simply run-as-root, but this is NOT
-         * recommended for security reasons.
-         *
-         * Memory locking means that the kernel can't swap out the page to disk - something that is unlikey to happen on a 
-         * command line system that isn't starved of memory. I haven't observed any difference on a CLI Linux system between 
-         * locked and unlocked memory. If that is your setup see option "no_mlck". 
-         */
+    }
 
-        /*
-         * use_slow_memory defines our behaviour with regards to large pages. There are three possible options here:
-         * always  - Don't even try to use large pages. Always use slow memory.
-         * warn    - We will try to use large pages, but fall back to slow memory if that fails.
-         * no_mlck - This option is only relevant on Linux, where we can use large pages without locking memory.
-         *           It will never use slow memory, but it won't attempt to mlock
-         * never   - If we fail to allocate large pages we will print an error and exit.
-         */
-        public string use_slow_memory = "warn";
-
-        /*
-         * NiceHash mode
-         * nicehash_nonce - Limit the noce to 3 bytes as required by nicehash. This cuts all the safety margins, and
-         *                  if a block isn't found within 30 minutes then you might run into nonce collisions. Number
-         *                  of threads in this mode is hard-limited to 32.
-         */
-        public readonly bool nicehash_nonce = true; // 
-
-        /*
-         * Manual hardware AES override
-         *
-         * Some VMs don't report AES capability correctly. You can set this value to true to enforce hardware AES or 
-         * to false to force disable AES or null to let the miner decide if AES is used.
-         * 
-         * WARNING: setting this to true on a CPU that doesn't support hardware AES will crash the miner.
-         */
-        public readonly bool? aes_override = null;
+    public class XmrDisableGPUConf
+    {
+        public List<JObject> gpu_threads_conf = new List<JObject>();
+        public readonly int platform_index = 0;
     }
 
     public class XmrStackCPUMiner : XmrStak
@@ -148,19 +137,38 @@ namespace NiceHashMiner.Miners {
                     if (IsHyperThreadingEnabled) {
                         numTr /= 2;
                     }
-                    var config = new XmrStackCPUMinerConfig(numTr, pool, wallet, this.APIPort);
+                    var cpuconf = new XmrStackCPUMinerConfig(numTr);
                     var no_prefetch = ExtraLaunchParametersParser.GetNoPrefetch(MiningSetup.MiningPairs[0]);
                     //config.Inti_cpu_threads_conf(false, false, true, ComputeDeviceManager.Avaliable.IsHyperThreadingEnabled);
-                    config.Inti_cpu_threads_conf(false, no_prefetch, false, IsHyperThreadingEnabled);
+                    cpuconf.Inti_cpu_threads_conf(false, no_prefetch, false, IsHyperThreadingEnabled);
+                    var cpuConfJson = JObject.FromObject(cpuconf);
+                    string writeStrCPU = cpuConfJson.ToString();
+                    int start = writeStrCPU.IndexOf("{");
+                    int end = writeStrCPU.LastIndexOf("}");
+                    writeStrCPU = writeStrCPU.Substring(start + 1, end - 1);
+                    System.IO.File.WriteAllText(WorkingDirectory + "cpu.txt", writeStrCPU);
+                    var config = new XmrStackMainMinerConfig(pool, wallet, this.APIPort);
                     var confJson = JObject.FromObject(config);
                     string writeStr = confJson.ToString();
-                    int start = writeStr.IndexOf("{");
-                    int end = writeStr.LastIndexOf("}");
+                    start = writeStr.IndexOf("{");
+                    end = writeStr.LastIndexOf("}");
                     writeStr = writeStr.Substring(start + 1, end - 1);
                     System.IO.File.WriteAllText(WorkingDirectory + GetConfigFileName(), writeStr);
-                } catch {
+                    var disableGPU = new XmrDisableGPUConf();
+                    var disableGPUconf = JObject.FromObject(disableGPU);
+                    writeStr = disableGPUconf.ToString();
+                    start = writeStr.IndexOf("{");
+                    end = writeStr.LastIndexOf("}");
+                    writeStr = writeStr.Substring(start + 1, end - 1);
+                    System.IO.File.WriteAllText(WorkingDirectory + "nvidia.txt", writeStr);
+                    System.IO.File.WriteAllText(WorkingDirectory + "amd.txt", writeStr);
+
+
                 }
-            }
+                catch (Exception e) {
+                Debug.WriteLine(e.Message);
+                }
+           }
         }
 
         protected override NiceHashProcess _Start() {

--- a/NiceHashMiner/Miners/XmrStak/XmrStak.cs
+++ b/NiceHashMiner/Miners/XmrStak/XmrStak.cs
@@ -14,7 +14,7 @@ namespace NiceHashMiner.Miners
         protected XmrStak(string name)
             : base(name) {
             ConectionType = NHMConectionType.NONE;
-            IsNeverHideMiningWindow = true;
+            IsNeverHideMiningWindow = false;
         }
 
         protected abstract void prepareConfigFile(string pool, string wallet);
@@ -42,7 +42,7 @@ namespace NiceHashMiner.Miners
                 return;
             }
             string username = GetUsername(btcAdress, worker);
-            LastCommandLine = GetConfigFileName();
+            LastCommandLine = "-c " + GetConfigFileName();
 
             prepareConfigFile(url, username);
 
@@ -52,7 +52,7 @@ namespace NiceHashMiner.Miners
         protected override string BenchmarkCreateCommandLine(Algorithm algorithm, int time) {
             string url = Globals.GetLocationURL(algorithm.NiceHashID, Globals.MiningLocation[ConfigManager.GeneralConfig.ServiceLocation], this.ConectionType);
             prepareConfigFile(url, Globals.DemoUser);
-            return "benchmark_mode " + GetConfigFileName();
+            return GetConfigFileName();
         }
         protected override bool BenchmarkParseLine(string outdata) {
             if (outdata.Contains("Total:")) {

--- a/NiceHashMiner/Miners/XmrStak/XmrStakConfig.cs
+++ b/NiceHashMiner/Miners/XmrStak/XmrStakConfig.cs
@@ -10,9 +10,11 @@ namespace NiceHashMiner.Miners
     public class XmrStakConfig
     {
         public XmrStakConfig(string poolAddr, string wallet, int port) {
-            pool_address = poolAddr;
-            wallet_address = wallet;
             httpd_port = port;
+            this.pool_list.Add(JObject.FromObject(new { pool_address = poolAddr,
+                wallet_address = wallet,
+                pool_password = "x",
+                use_nicehash = true, use_tls = this.use_tls, tls_fingerprint = this.tls_fingerprint, pool_weight = 1 }));
         }
 
         /*
@@ -27,15 +29,20 @@ namespace NiceHashMiner.Miners
         public readonly bool use_tls = false;
         public readonly bool tls_secure_algo = true;
         public readonly string tls_fingerprint = "";
+        public readonly string currency = "monero";
+        public readonly bool print_motd = false;
+        public readonly string http_login = "";
+        public readonly string http_pass = "";
+        public readonly bool flush_stdout = false;
+
 
         /*
          * pool_address	  - Pool address should be in the form "pool.supportxmr.com:3333". Only stratum pools are supported.
          * wallet_address - Your wallet, or pool login.
          * pool_password  - Can be empty in most cases or "x".
          */
-        public readonly string pool_address; // : "pool.supportxmr.com:3333",
-        public readonly string wallet_address;
-        public readonly string pool_password = "x";
+
+        public List<JObject> pool_list = new List<JObject>();
 
         /*
          * Network timeouts.

--- a/NiceHashMiner/Utils/MinersDownloadManager.cs
+++ b/NiceHashMiner/Utils/MinersDownloadManager.cs
@@ -15,7 +15,7 @@ using NiceHashMiner.Devices;
 namespace NiceHashMiner.Utils {
     public static class MinersDownloadManager {
         public static DownloadSetup StandardDlSetup = new DownloadSetup(
-            "http://github.com/NiceHash/NiceHashMinerLegacy/releases/download/1.8.1.5/bin_1_8_1_5.zip",
+            "http://github.com/uaktags/NiceHashMinerLegacy/releases/download/1.8.1.6-pre1-xmrstak/bin_1_8_1_6_pre1.zip",
             "bins.zip",
             "bin");
 


### PR DESCRIPTION
This PR is just to show the starting progress of porting NHML to use XMR-Stak rather than XMR-Stak-CPU due to its discontinuation. Benchmar_mode doesn't work, so you need to hack that via the .json until I or someone else can figure that part out.

By all means, rip this apart and clean it up if you feel that XMR-Stak is a good idea.