### PR TITLE
Colorized log console

### DIFF
--- a/NiceHashMiner/International.cs
+++ b/NiceHashMiner/International.cs
@@ -9,6 +9,8 @@ namespace NiceHashMiner
 {
     class International
     {
+        public static readonly log4net.ILog log = log4net.LogManager.GetLogger("LANGUAGE");
+
         private class Language
         {
 #pragma warning disable 649
@@ -38,13 +40,13 @@ namespace NiceHashMiner
                     }
                     catch (Exception ex)
                     {
-                        Helpers.ConsolePrint("NICEHASH", "Lang error: " + ex.Message);
+                        log.Error(ex.Message);
                     }
                 }
             }
             catch (Exception ex)
             {
-                Helpers.ConsolePrint("NICEHASH", "Lang error: " + ex.Message);
+                log.Error(ex.Message);
             }
 
             return langs;
@@ -58,13 +60,13 @@ namespace NiceHashMiner
             {
                 if (lang.ID == lid)
                 {
-                    Helpers.ConsolePrint("NICEHASH", "Selected language: " + lang.Name);
+                    log.Info("Selected language: " + lang.Name);
                     SelectedLanguage = lang;
                     return;
                 }
             }
-            
-            Helpers.ConsolePrint("NICEHASH", "Critical error: missing language");
+
+            log.Error("Critical error: missing language");
         }
 
         /// <summary>
@@ -78,7 +80,7 @@ namespace NiceHashMiner
 
             foreach (Language lang in langs)
             {
-                Helpers.ConsolePrint("NICEHASH", "Found language: " + lang.Name);
+                log.Debug("Found language: " + lang.Name);
                 retdict.Add(lang.ID, lang.Name);
             }
 

--- a/NiceHashMiner/Program.cs
+++ b/NiceHashMiner/Program.cs
@@ -59,10 +59,10 @@ namespace NiceHashMiner
                 }
 
                 if (ConfigManager.GeneralConfig.LogToFile) {
-                    Logger.ConfigureWithFile();
+                    Logger.ConfigureLog();
                 }
-
-
+    
+                
                 // init active display currency after config load
                 ExchangeRateAPI.ActiveDisplayCurrency = ConfigManager.GeneralConfig.DisplayCurrency;
 
@@ -89,8 +89,6 @@ namespace NiceHashMiner
                 if (Helpers.IsWMIEnabled()) {
                     if (ConfigManager.GeneralConfig.agreedWithTOS == Globals.CURRENT_TOS_VER) {
                         Application.Run(new Form_Main());
-                        Console.WriteLine("Press to exit");
-                        Console.ReadLine();
                     }
                 }
                 else {

--- a/NiceHashMiner/Utils/Helpers.cs
+++ b/NiceHashMiner/Utils/Helpers.cs
@@ -14,7 +14,7 @@ namespace NiceHashMiner
 {
     class Helpers : PInvokeHelpers
     {
-        
+        public static readonly log4net.ILog log = log4net.LogManager.GetLogger("HELPERS");
 
         static bool is64BitProcess = (IntPtr.Size == 8);
         public static bool Is64BitOperatingSystem = is64BitProcess || InternalCheckIsWow64();
@@ -43,15 +43,15 @@ namespace NiceHashMiner
         public static void ConsolePrint(string grp, string text)
         {
             // Console.WriteLine does nothing on x64 while debugging with VS, so use Debug. Console.WriteLine works when run from .exe
-#if DEBUG
-            Debug.WriteLine("[" + DateTime.Now.ToLongTimeString() + "] [" + grp + "] " + text);
-#endif
-#if !DEBUG
-            Console.WriteLine("[" +DateTime.Now.ToLongTimeString() + "] [" + grp + "] " + text);
-#endif
+            //#if DEBUG
+            //Debug.WriteLine("[" + DateTime.Now.ToLongTimeString() + "] [" + grp + "] " + text);
+            //#endif
+            //#if !DEBUG
+            //Console.WriteLine("[" +DateTime.Now.ToLongTimeString() + "] [" + grp + "] " + text);
+            //#endif
 
-            if (ConfigManager.GeneralConfig.LogToFile && Logger.IsInit)
-                Logger.log.Info("[" + grp + "] " + text);
+            //if (ConfigManager.GeneralConfig.LogToFile && Logger.IsInit)
+            Logger.log.Debug("[" + grp + "] " + text);
         }
 
         public static void ConsolePrint(string grp, string text, params object[] arg)
@@ -87,7 +87,7 @@ namespace NiceHashMiner
         {
             //bool failed = false;
 
-            Helpers.ConsolePrint("NICEHASH", "Trying to enable/disable Windows error reporting");
+            log.Debug("Trying to enable/disable Windows error reporting");
 
             // CurrentUser
             try
@@ -100,34 +100,34 @@ namespace NiceHashMiner
                         if (o != null)
                         {
                             int val = (int)o;
-                            Helpers.ConsolePrint("NICEHASH", "Current DontShowUI value: " + val);
+                            log.Info("Current DontShowUI value: " + val);
 
                             if (val == 0 && en)
                             {
-                                Helpers.ConsolePrint("NICEHASH", "Setting register value to 1.");
+                                log.Debug("Setting register value to 1.");
                                 rk.SetValue("DontShowUI", 1);
                             }
                             else if (val == 1 && !en)
                             {
-                                Helpers.ConsolePrint("NICEHASH", "Setting register value to 0.");
+                                log.Debug("Setting register value to 0.");
                                 rk.SetValue("DontShowUI", 0);
                             }
                         }
                         else
                         {
-                            Helpers.ConsolePrint("NICEHASH", "Registry key not found .. creating one..");
+                            log.Debug("Registry key not found .. creating one..");
                             rk.CreateSubKey("DontShowUI", RegistryKeyPermissionCheck.Default);
-                            Helpers.ConsolePrint("NICEHASH", "Setting register value to 1..");
+                            log.Debug("Setting register value to 1..");
                             rk.SetValue("DontShowUI", en ? 1 : 0);
                         }
                     }
                     else
-                        Helpers.ConsolePrint("NICEHASH", "Unable to open SubKey.");
+                        log.Warn("Unable to open SubKey.");
                 }
             }
             catch (Exception ex)
             {
-                Helpers.ConsolePrint("NICEHASH", "Unable to access registry. Error: " + ex.Message);
+                log.Error("Unable to access registry. Error: " + ex.Message);
             }
         }
 
@@ -273,11 +273,11 @@ namespace NiceHashMiner
         public static bool IsWMIEnabled() {
             try {
                 ManagementObjectCollection moc = new ManagementObjectSearcher("root\\CIMV2", "SELECT * FROM Win32_OperatingSystem").Get();
-                ConsolePrint("NICEHASH", "WMI service seems to be running, ManagementObjectSearcher returned success.");
+                log.Debug("WMI service seems to be running, ManagementObjectSearcher returned success.");
                 return true;
             }
             catch {
-                ConsolePrint("NICEHASH", "ManagementObjectSearcher not working need WMI service to be running");
+                log.Debug("ManagementObjectSearcher not working need WMI service to be running");
             }
             return false;
         }
@@ -298,7 +298,7 @@ namespace NiceHashMiner
 
         public static void SetDefaultEnvironmentVariables()
         {
-            Helpers.ConsolePrint("NICEHASH", "Setting environment variables");
+            log.Debug("Setting environment variables");
 
             Dictionary<string, string> envNameValues = new Dictionary<string, string>() {
                 { "GPU_MAX_ALLOC_PERCENT",      "100" },
@@ -315,14 +315,14 @@ namespace NiceHashMiner
                 if (Environment.GetEnvironmentVariable(envName) == null)
                 {
                     try { Environment.SetEnvironmentVariable(envName, envValue); }
-                    catch (Exception e) { Helpers.ConsolePrint("NICEHASH", e.ToString()); }
+                    catch (Exception e) { log.Error(e.ToString()); }
                 }
 
                 // Check to make sure all the values are set correctly
                 if (!Environment.GetEnvironmentVariable(envName).Equals(envValue))
                 {
                     try { Environment.SetEnvironmentVariable(envName, envValue); }
-                    catch (Exception e) { Helpers.ConsolePrint("NICEHASH", e.ToString()); }
+                    catch (Exception e) { log.Error(e.ToString()); }
                 }
             }
         }
@@ -339,13 +339,13 @@ namespace NiceHashMiner
                 Process p = Process.Start(psi);
                 p.WaitForExit();
                 if (p.ExitCode != 0)
-                    Helpers.ConsolePrint("NICEHASH", "nvidiasetp0state returned error code: " + p.ExitCode.ToString());
+                    log.Debug("nvidiasetp0state returned error code: " + p.ExitCode.ToString());
                 else
-                    Helpers.ConsolePrint("NICEHASH", "nvidiasetp0state all OK");
+                    log.Debug("nvidiasetp0state all OK");
             }
             catch (Exception ex)
             {
-                Helpers.ConsolePrint("NICEHASH", "nvidiasetp0state error: " + ex.Message);
+                log.Error("nvidiasetp0state error: " + ex.Message);
             }
         }
     }

--- a/NiceHashMiner/Utils/Logger.cs
+++ b/NiceHashMiner/Utils/Logger.cs
@@ -30,16 +30,23 @@ namespace NiceHashMiner
             try {
                 Hierarchy h = (Hierarchy)LogManager.GetRepository();
 
-                if (ConfigManager.GeneralConfig.LogToFile)
-                    h.Root.Level = Level.Info;
+                //if (ConfigManager.GeneralConfig.LogToFile)
+                //    h.Root.Level = Level.Info;
                 //else if (ConfigManager.Instance.GeneralConfig.LogLevel == 2)
                 //    h.Root.Level = Level.Warn;
                 //else if (ConfigManager.Instance.GeneralConfig.LogLevel == 3)
                 //    h.Root.Level = Level.Error;
 
-                h.Root.AddAppender(CreateFileAppender());
+                if (ConfigManager.GeneralConfig.LogToFile)
+                    h.Root.AddAppender(CreateFileAppender());
+
+#if DEBUG
+                h.Root.AddAppender(CreateDebugAppender());
+#else
+                h.Root.AddAppender(CreateColoredConsoleAppender());
+#endif
                 h.Configured = true;
-            } catch (Exception e) {
+            } catch (Exception) {
                 IsInit = false;
             }
         }
@@ -63,6 +70,53 @@ namespace NiceHashMiner
             appender.Layout = layout;
             appender.ActivateOptions();
 
+            return appender;
+        }
+
+        public static IAppender CreateDebugAppender()
+        {
+            PatternLayout debugLayout = new PatternLayout();
+            debugLayout.ConversionPattern = "[%date{MM.dd HH:mm:ss,fff}] [%thread] [%-5level] - %message%newline";
+            debugLayout.ActivateOptions();
+            DebugAppender debugAppender = new DebugAppender();
+            debugAppender.Layout = debugLayout;
+            debugAppender.ActivateOptions();
+
+            return debugAppender;
+        }
+
+        public static IAppender CreateColoredConsoleAppender()
+        {
+            PatternLayout layout = new PatternLayout();
+            layout.ConversionPattern = "[%date{MM.dd HH:mm:ss,fff}] [%thread] [%-5level] - %message%newline";
+            layout.ActivateOptions();
+            var appender = new ColoredConsoleAppender { Layout = layout };
+            appender.AddMapping(new ColoredConsoleAppender.LevelColors
+            {
+                Level = Level.Debug,
+                ForeColor = ColoredConsoleAppender.Colors.Green
+            });
+            appender.AddMapping(new ColoredConsoleAppender.LevelColors
+            {
+                Level = Level.Info,
+                ForeColor = ColoredConsoleAppender.Colors.White
+            });
+            appender.AddMapping(new ColoredConsoleAppender.LevelColors
+            {
+                Level = Level.Warn,
+                ForeColor = ColoredConsoleAppender.Colors.Yellow
+            });
+            appender.AddMapping(new ColoredConsoleAppender.LevelColors
+            {
+                Level = Level.Error,
+                ForeColor = ColoredConsoleAppender.Colors.Red
+            });
+            appender.AddMapping(new ColoredConsoleAppender.LevelColors
+            {
+                Level = Level.Fatal,
+                ForeColor = ColoredConsoleAppender.Colors.HighIntensity | ColoredConsoleAppender.Colors.Red
+            });
+            appender.ActivateOptions();
             return appender;
         }
     }

--- a/NiceHashMiner/Utils/Logger.cs
+++ b/NiceHashMiner/Utils/Logger.cs
@@ -43,7 +43,9 @@ namespace NiceHashMiner
 #if DEBUG
                 h.Root.AddAppender(CreateDebugAppender());
 #else
-                h.Root.AddAppender(CreateColoredConsoleAppender());
+                if (ConfigManager.GeneralConfig.DebugConsole) {
+                    h.Root.AddAppender(CreateColoredConsoleAppender());
+                }
 #endif
                 h.Configured = true;
             } catch (Exception) {

--- a/NiceHashMiner/Utils/Logger.cs
+++ b/NiceHashMiner/Utils/Logger.cs
@@ -18,7 +18,7 @@ namespace NiceHashMiner
 
         public const string _logPath = @"logs\";
 
-        public static void ConfigureWithFile()
+        public static void ConfigureLog()
         {
             try {
                 if (!Directory.Exists("logs")) {
@@ -94,12 +94,12 @@ namespace NiceHashMiner
             appender.AddMapping(new ColoredConsoleAppender.LevelColors
             {
                 Level = Level.Debug,
-                ForeColor = ColoredConsoleAppender.Colors.Green
+                ForeColor = ColoredConsoleAppender.Colors.White
             });
             appender.AddMapping(new ColoredConsoleAppender.LevelColors
             {
                 Level = Level.Info,
-                ForeColor = ColoredConsoleAppender.Colors.White
+                ForeColor = ColoredConsoleAppender.Colors.Green
             });
             appender.AddMapping(new ColoredConsoleAppender.LevelColors
             {


### PR DESCRIPTION
All messages in the log contain [INFO] that it does not make sense to include it there. It will be better to use other keys (DEBUG, WARN, ERROR, FATAL). and a simple output to the console prevents all messages from being difficult to read. so do not add a little color.
![colored](https://user-images.githubusercontent.com/30864287/32987104-3c781dba-cd1c-11e7-8da3-2654acd495e2.png)
