### PR TITLE
on changed rpc credentials restart miners to use new ones

### DIFF
--- a/src/NiceHashMinerLegacy/Miners/MinersManager.cs
+++ b/src/NiceHashMinerLegacy/Miners/MinersManager.cs
@@ -61,6 +61,16 @@ namespace NiceHashMiner.Miners
             _curMiningSession?.UpdateUsedDevices(devices);
         }
 
+        public static void UpdateBTC(string btc)
+        {
+            _curMiningSession?.UpdateBTC(btc);
+        }
+
+        public static void UpdateWorker(string worker)
+        {
+            _curMiningSession?.UpdateWorker(worker);
+        }
+
 
         /// <summary>
         /// SwichMostProfitable should check the best combination for most profit.

--- a/src/NiceHashMinerLegacy/Miners/MiningSession.cs
+++ b/src/NiceHashMinerLegacy/Miners/MiningSession.cs
@@ -286,18 +286,18 @@ namespace NiceHashMiner.Miners
 
         public void UpdateBTC(string btc)
         {
-            _switchingManager.Stop(); // TODO NOT SURE?
+            _switchingManager.Stop();
             _btcAdress = btc;
             RestartRunningGroupMiners();
-            _switchingManager.Start(); // TODO NOT SURE?
+            _switchingManager.Start();
         }
 
         public void UpdateWorker(string worker)
         {
-            _switchingManager.Stop();  // TODO NOT SURE?
+            _switchingManager.Stop();
             _worker = worker;
             RestartRunningGroupMiners();
-            _switchingManager.Start();  // TODO NOT SURE?
+            _switchingManager.Start();
         }
 
         private void SetUsedDevices(IEnumerable<ComputeDevice> devices)

--- a/src/NiceHashMinerLegacy/Miners/MiningSession.cs
+++ b/src/NiceHashMinerLegacy/Miners/MiningSession.cs
@@ -28,8 +28,8 @@ namespace NiceHashMiner.Miners
         // session varibles fixed
         private readonly string _miningLocation;
 
-        private readonly string _btcAdress;
-        private readonly string _worker;
+        private string _btcAdress;
+        private string _worker;
         private List<MiningDevice> _miningDevices;
         private readonly IRatesComunication _ratesComunication;
 
@@ -273,6 +273,31 @@ namespace NiceHashMiner.Miners
             _switchingManager.Stop();
             SetUsedDevices(devices);
             _switchingManager.Start();
+        }
+
+        private void RestartRunningGroupMiners()
+        {
+            foreach (var key in _runningGroupMiners.Keys)
+            {
+                _runningGroupMiners[key].Stop();
+                _runningGroupMiners[key].Start(_miningLocation, _btcAdress, _worker);
+            }
+        }
+
+        public void UpdateBTC(string btc)
+        {
+            _switchingManager.Stop(); // TODO NOT SURE?
+            _btcAdress = btc;
+            RestartRunningGroupMiners();
+            _switchingManager.Start(); // TODO NOT SURE?
+        }
+
+        public void UpdateWorker(string worker)
+        {
+            _switchingManager.Stop();  // TODO NOT SURE?
+            _worker = worker;
+            RestartRunningGroupMiners();
+            _switchingManager.Start();  // TODO NOT SURE?
         }
 
         private void SetUsedDevices(IEnumerable<ComputeDevice> devices)

--- a/src/NiceHashMinerLegacy/Stats/NiceHashStats.cs
+++ b/src/NiceHashMinerLegacy/Stats/NiceHashStats.cs
@@ -177,22 +177,24 @@ namespace NiceHashMiner.Stats
                     return null;
                 case "mining.set.username":
                     executed = true;
-                    var user = (string) message.username;
+                    var user = (string)message.username;
 
                     if (!BitcoinAddress.ValidateBitcoinAddress(user))
                         throw new RpcException("Bitcoin address invalid", 1);
 
                     ConfigManager.GeneralConfig.BitcoinAddress = user;
-                    return new ExecutedInfo {NewBtc = user};
+                    MinersManager.UpdateBTC(user);
+                    return new ExecutedInfo { NewBtc = user };
                 case "mining.set.worker":
                     executed = true;
-                    var worker = (string) message.worker;
+                    var worker = (string)message.worker;
 
                     if (!BitcoinAddress.ValidateWorkerName(worker))
                         throw new RpcException("Worker name invalid", 1);
 
                     ConfigManager.GeneralConfig.WorkerName = worker;
-                    return new ExecutedInfo {NewWorker = worker};
+                    MinersManager.UpdateWorker(worker);
+                    return new ExecutedInfo { NewWorker = worker };
                 case "mining.set.group":
                     executed = true;
                     var group = (string) message.group;


### PR DESCRIPTION
When credentials get changed with websocket RPC calls restart actual miners. This commit only restarts actual miners.

GUI and Settings are still broken.