### PR TITLE
Add NBMiner support

### DIFF
--- a/NiceHashMinerLegacy.sln.DotSettings
+++ b/NiceHashMinerLegacy.sln.DotSettings
@@ -3,6 +3,7 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=CT/@EntryIndexedValue">CT</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=ID/@EntryIndexedValue">ID</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=MH/@EntryIndexedValue">MH</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=NB/@EntryIndexedValue">NB</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=NH/@EntryIndexedValue">NH</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=NV/@EntryIndexedValue">NV</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=OK/@EntryIndexedValue">OK</s:String>

--- a/src/NiceHashMinerLegacy.Common/Enums/MinerBaseType.cs
+++ b/src/NiceHashMinerLegacy.Common/Enums/MinerBaseType.cs
@@ -29,6 +29,7 @@
         GMiner,
         BMiner,
         TTMiner,
+        NBMiner,
         END
     }
 }

--- a/src/NiceHashMinerLegacy.Extensions/StringExt.cs
+++ b/src/NiceHashMinerLegacy.Extensions/StringExt.cs
@@ -42,7 +42,7 @@ namespace NiceHashMinerLegacy.Extensions
         public static string GetStringAfter(this string s, string after)
         {
             var index = s.IndexOf(after, StringComparison.Ordinal);
-            return s.Substring(index);
+            return s.Substring(index + after.Length);
         }
     }
 }

--- a/src/NiceHashMinerLegacy/Devices/Algorithms/DefaultAlgorithms.cs
+++ b/src/NiceHashMinerLegacy/Devices/Algorithms/DefaultAlgorithms.cs
@@ -269,6 +269,14 @@ namespace NiceHashMiner.Devices.Algorithms
                     new Algorithm(MinerBaseType.TTMiner, AlgorithmType.MTP),
                     new Algorithm(MinerBaseType.TTMiner, AlgorithmType.Lyra2REv3),
                 }
+            },
+            {
+                MinerBaseType.NBMiner,
+                new List<Algorithm>
+                {
+                    new Algorithm(MinerBaseType.NBMiner, AlgorithmType.GrinCuckaroo29),
+                    new Algorithm(MinerBaseType.NBMiner, AlgorithmType.GrinCuckatoo31)
+                }
             }
             
         }.ConcatDictList(All, Gpu);

--- a/src/NiceHashMinerLegacy/Devices/ComputeDevice/ComputeDevice.cs
+++ b/src/NiceHashMinerLegacy/Devices/ComputeDevice/ComputeDevice.cs
@@ -345,7 +345,9 @@ namespace NiceHashMiner.Devices
                 MinerBaseType.trex,
                 MinerBaseType.Phoenix,
                 MinerBaseType.GMiner,
-                MinerBaseType.BMiner
+                MinerBaseType.BMiner,
+                MinerBaseType.TTMiner,
+                MinerBaseType.NBMiner
             };
 
             return AlgorithmSettings.FindAll(a => thirdPartyMiners.IndexOf(a.MinerBaseType) == -1);

--- a/src/NiceHashMinerLegacy/Interfaces/IApiResult.cs
+++ b/src/NiceHashMinerLegacy/Interfaces/IApiResult.cs
@@ -1,0 +1,7 @@
+﻿namespace NiceHashMiner.Interfaces
+{
+    public interface IApiResult
+    {
+        double? TotalHashrate { get; }
+    }
+}

--- a/src/NiceHashMinerLegacy/Miners/BMiner.cs
+++ b/src/NiceHashMinerLegacy/Miners/BMiner.cs
@@ -1,20 +1,18 @@
-﻿using NiceHashMiner.Algorithms;
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using NiceHashMiner.Algorithms;
+using NiceHashMiner.Configs;
 using NiceHashMinerLegacy.Common.Enums;
+using NiceHashMinerLegacy.Extensions;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
-using NiceHashMiner.Configs;
-using NiceHashMinerLegacy.Extensions;
 
 namespace NiceHashMiner.Miners
 {
-    public class BMiner : Miner
+    public class BMiner : VanillaProcessMiner
     {
         #region JSON Models
 
@@ -52,8 +50,6 @@ namespace NiceHashMiner.Miners
         #endregion
 
         private readonly HttpClient _httpClient;
-
-        private Process _process;
 
         private double _benchHashes = 0;
         private int _benchIters = 0;
@@ -169,83 +165,6 @@ namespace NiceHashMiner.Miners
             LastCommandLine = CreateCommandLine(url, btcAdress, worker);
 
             _Start();
-        }
-
-        // BMiner throws a fit if started with NiceHashProcess so use System.Diagnostics.Process instead
-        // WARNING ProcessHandle will be null so do not call methods that access it (currently _Stop() is the only
-        // one and it is overridden here)
-        // TODO is NiceHashProcess necessary or can we use System.Diagnostics.Process everywhere?
-        protected override NiceHashProcess _Start(IReadOnlyDictionary<string, string> envVariables = null)
-        {
-            if (_isEnded)
-            {
-                return null;
-            }
-
-            _process = new Process();
-
-            Ethlargement.CheckAndStart(MiningSetup);
-
-            var nhmlDirectory = Directory.GetCurrentDirectory();
-            _process.StartInfo.WorkingDirectory = System.IO.Path.Combine(nhmlDirectory, WorkingDirectory);
-            _process.StartInfo.FileName = System.IO.Path.Combine(nhmlDirectory, Path);
-            _process.StartInfo.Arguments = LastCommandLine;
-            _process.Exited += (sender, args) =>
-            {
-                Miner_Exited();
-            };
-            _process.EnableRaisingEvents = true;
-            _process.StartInfo.CreateNoWindow = ConfigManager.GeneralConfig.HideMiningWindows;
-
-            _process.StartInfo.UseShellExecute = false;
-
-            try
-            {
-                if (_process.Start())
-                {
-                    IsRunning = true;
-
-                    _currentPidData = new MinerPidData
-                    {
-                        MinerBinPath = Path,
-                        Pid = _process.Id
-                    };
-                    _allPidData.Add(_currentPidData);
-
-                    Helpers.ConsolePrint(MinerTag(), "Starting miner " + ProcessTag() + " " + LastCommandLine);
-
-                    StartCoolDownTimerChecker();
-                }
-                else
-                {
-                    Helpers.ConsolePrint(MinerTag(), "NOT STARTED " + ProcessTag() + " " + LastCommandLine);
-                }
-            }
-            catch (Exception ex)
-            {
-                Helpers.ConsolePrint(MinerTag(), ProcessTag() + " _Start: " + ex.Message);
-            }
-
-            return null;
-        }
-
-        protected override void _Stop(MinerStopType willswitch)
-        {
-            if (IsRunning)
-            {
-                Helpers.ConsolePrint(MinerTag(), ProcessTag() + " Shutting down miner");
-            }
-
-            if (_process == null) return;
-
-            try
-            {
-                _process.Kill();
-            }
-            catch { }
-
-            _process.Close();
-            _process = null;
         }
 
         protected override string BenchmarkCreateCommandLine(Algorithm algorithm, int time)

--- a/src/NiceHashMinerLegacy/Miners/GMiner.cs
+++ b/src/NiceHashMinerLegacy/Miners/GMiner.cs
@@ -8,6 +8,7 @@ using Newtonsoft.Json;
 using NiceHashMiner.Algorithms;
 using NiceHashMiner.Configs;
 using NiceHashMiner.Devices;
+using NiceHashMiner.Interfaces;
 using NiceHashMiner.Miners.Parsing;
 using NiceHashMinerLegacy.Common.Enums;
 using NiceHashMinerLegacy.Extensions;
@@ -26,7 +27,7 @@ namespace NiceHashMiner.Miners
         private double _benchHashes;
         private int _targetBenchIters;
 
-        private class JsonModel
+        private class JsonModel : IApiResult
         {
             public class DeviceEntry
             {
@@ -35,6 +36,8 @@ namespace NiceHashMiner.Miners
             }
 
             public List<DeviceEntry> devices;
+
+            public double? TotalHashrate => devices?.Sum(d => d.speed);
         }
 
         private string AlgoName
@@ -145,25 +148,9 @@ namespace NiceHashMiner.Miners
             base.BenchmarkThreadRoutineFinish();
         }
 
-        public override async Task<ApiData> GetSummaryAsync()
+        public override Task<ApiData> GetSummaryAsync()
         {
-            CurrentMinerReadStatus = MinerApiReadStatus.NONE;
-            var api = new ApiData(MiningSetup.CurrentAlgorithmType);
-            try
-            {
-                var result = await _httpClient.GetStringAsync($"http://127.0.0.1:{ApiPort}/stat");
-                var summary = JsonConvert.DeserializeObject<JsonModel>(result);
-                api.Speed = summary.devices.Sum(d => d.speed);
-                CurrentMinerReadStatus =
-                    api.Speed <= 0 ? MinerApiReadStatus.READ_SPEED_ZERO : MinerApiReadStatus.GOT_READ;
-            }
-            catch (Exception e)
-            {
-                CurrentMinerReadStatus = MinerApiReadStatus.NETWORK_EXCEPTION;
-                Helpers.ConsolePrint(MinerTag(), e.Message);
-            }
-
-            return api;
+            return GetHttpSummaryAsync<JsonModel>("stat");
         }
     }
 }

--- a/src/NiceHashMinerLegacy/Miners/GMiner.cs
+++ b/src/NiceHashMinerLegacy/Miners/GMiner.cs
@@ -1,17 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net.Http;
-using System.Text;
-using System.Threading.Tasks;
-using Newtonsoft.Json;
-using NiceHashMiner.Algorithms;
+﻿using NiceHashMiner.Algorithms;
 using NiceHashMiner.Configs;
 using NiceHashMiner.Devices;
 using NiceHashMiner.Interfaces;
 using NiceHashMiner.Miners.Parsing;
 using NiceHashMinerLegacy.Common.Enums;
 using NiceHashMinerLegacy.Extensions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 
 namespace NiceHashMiner.Miners
 {
@@ -20,8 +17,6 @@ namespace NiceHashMiner.Miners
     public class GMiner : Miner
     {
         private const double DevFee = 2.0;
-
-        private readonly HttpClient _httpClient;
 
         private int _benchIters;
         private double _benchHashes;
@@ -63,7 +58,6 @@ namespace NiceHashMiner.Miners
         public GMiner() : base("gminer")
         {
             ConectionType = NhmConectionType.NONE;
-            _httpClient = new HttpClient();
         }
 
         protected override int GetMaxCooldownTimeInMilliseconds()

--- a/src/NiceHashMinerLegacy/Miners/Grouping/MinerPaths.cs
+++ b/src/NiceHashMinerLegacy/Miners/Grouping/MinerPaths.cs
@@ -137,7 +137,7 @@ namespace NiceHashMiner.Miners.Grouping
 
             public const string TTMiner = Bin3rdParty + @"\ttminer\TT-Miner.exe";
 
-            public const string NBMiner = Bin3rdParty + @"nbminer\nbminer.exe";
+            public const string NBMiner = Bin3rdParty + @"\nbminer\nbminer.exe";
         }
 
         // NEW START

--- a/src/NiceHashMinerLegacy/Miners/Grouping/MinerPaths.cs
+++ b/src/NiceHashMinerLegacy/Miners/Grouping/MinerPaths.cs
@@ -136,6 +136,8 @@ namespace NiceHashMiner.Miners.Grouping
             public const string BMiner = Bin3rdParty + @"\bminer\bminer.exe";
 
             public const string TTMiner = Bin3rdParty + @"\ttminer\TT-Miner.exe";
+
+            public const string NBMiner = Bin3rdParty + @"nbminer\nbminer.exe";
         }
 
         // NEW START
@@ -234,6 +236,8 @@ namespace NiceHashMiner.Miners.Grouping
                     return Data.GMiner;
                 case MinerBaseType.BMiner:
                     return Data.BMiner;
+                case MinerBaseType.NBMiner:
+                    return Data.NBMiner;
             }
             return Data.None;
         }

--- a/src/NiceHashMinerLegacy/Miners/Miner.cs
+++ b/src/NiceHashMinerLegacy/Miners/Miner.cs
@@ -10,6 +10,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Net.Http;
 using System.Net.Sockets;
 using System.Text;
 using System.Threading;
@@ -140,6 +141,8 @@ namespace NiceHashMiner
         protected const string HttpHeaderDelimiter = "\r\n\r\n";
 
         protected bool IsMultiType;
+
+        private readonly Lazy<HttpClient> _httpClient = new Lazy<HttpClient>();
 
         protected Miner(string minerDeviceName)
         {
@@ -1149,6 +1152,28 @@ namespace NiceHashMiner
         }
 
         public abstract Task<ApiData> GetSummaryAsync();
+
+        protected async Task<ApiData> GetHttpSummaryAsync<TJsonModel>(string endpoint)
+            where TJsonModel : IApiResult
+        {
+            CurrentMinerReadStatus = MinerApiReadStatus.NONE;
+            var api = new ApiData(MiningSetup.CurrentAlgorithmType);
+            try
+            {
+                var result = await _httpClient.Value.GetStringAsync($"http://127.0.0.1:{ApiPort}/{endpoint}");
+                var summary = JsonConvert.DeserializeObject<TJsonModel>(result);
+                api.Speed = summary.TotalHashrate ?? 0;
+                CurrentMinerReadStatus =
+                    api.Speed <= 0 ? MinerApiReadStatus.READ_SPEED_ZERO : MinerApiReadStatus.GOT_READ;
+            }
+            catch (Exception e)
+            {
+                CurrentMinerReadStatus = MinerApiReadStatus.NETWORK_EXCEPTION;
+                Helpers.ConsolePrint(MinerTag(), e.Message);
+            }
+
+            return api;
+        }
 
         protected async Task<ApiData> GetSummaryCpuAsync(string method = "", bool overrideLoop = false)
         {

--- a/src/NiceHashMinerLegacy/Miners/Miner.cs
+++ b/src/NiceHashMinerLegacy/Miners/Miner.cs
@@ -449,6 +449,11 @@ namespace NiceHashMiner
             }
             else
             {
+                if (this is NBMiner)
+                {
+                    benchmarkHandle.StartInfo.FileName =
+                        System.IO.Path.Combine(Environment.CurrentDirectory, MiningSetup.MinerPath);
+                }
                 BenchmarkProcessPath = benchmarkHandle.StartInfo.FileName;
                 Helpers.ConsolePrint(MinerTag(), "Using miner: " + benchmarkHandle.StartInfo.FileName);
                 benchmarkHandle.StartInfo.WorkingDirectory = WorkingDirectory;
@@ -561,7 +566,7 @@ namespace NiceHashMiner
             }
         }
 
-        public void InvokeBenchmarkSignalQuit()
+        public virtual void InvokeBenchmarkSignalQuit()
         {
             KillAllUsedMinerProcesses();
         }

--- a/src/NiceHashMinerLegacy/Miners/Miner.cs
+++ b/src/NiceHashMinerLegacy/Miners/Miner.cs
@@ -449,11 +449,6 @@ namespace NiceHashMiner
             }
             else
             {
-                if (this is NBMiner)
-                {
-                    benchmarkHandle.StartInfo.FileName =
-                        System.IO.Path.Combine(Environment.CurrentDirectory, MiningSetup.MinerPath);
-                }
                 BenchmarkProcessPath = benchmarkHandle.StartInfo.FileName;
                 Helpers.ConsolePrint(MinerTag(), "Using miner: " + benchmarkHandle.StartInfo.FileName);
                 benchmarkHandle.StartInfo.WorkingDirectory = WorkingDirectory;

--- a/src/NiceHashMinerLegacy/Miners/MinerFactory.cs
+++ b/src/NiceHashMinerLegacy/Miners/MinerFactory.cs
@@ -100,6 +100,8 @@ namespace NiceHashMiner.Miners
                     return new GMiner();
                 case MinerBaseType.BMiner:
                     return new BMiner(algorithm.NiceHashID);
+                case MinerBaseType.NBMiner:
+                    return new NBMiner();
             }
 
             return null;

--- a/src/NiceHashMinerLegacy/Miners/NBMiner.cs
+++ b/src/NiceHashMinerLegacy/Miners/NBMiner.cs
@@ -1,13 +1,11 @@
 ﻿using NiceHashMiner.Algorithms;
+using NiceHashMiner.Interfaces;
 using NiceHashMiner.Miners.Parsing;
 using NiceHashMinerLegacy.Common.Enums;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net.Http;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
-using NiceHashMiner.Interfaces;
 
 namespace NiceHashMiner.Miners
 {
@@ -31,8 +29,6 @@ namespace NiceHashMiner.Miners
 
             public double? TotalHashrate => miner?.total_hashrate;
         }
-
-        private readonly HttpClient _http = new HttpClient();
 
         private string AlgoName
         {

--- a/src/NiceHashMinerLegacy/Miners/NBMiner.cs
+++ b/src/NiceHashMinerLegacy/Miners/NBMiner.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NiceHashMiner.Algorithms;
+using NiceHashMiner.Miners.Parsing;
+using NiceHashMinerLegacy.Common.Enums;
+
+namespace NiceHashMiner.Miners
+{
+    public class NBMiner : Miner
+    {
+        private string AlgoName
+        {
+            get
+            {
+                switch (MiningSetup.CurrentAlgorithmType)
+                {
+                    case AlgorithmType.GrinCuckaroo29:
+                        return "cuckaroo";
+                    case AlgorithmType.GrinCuckatoo31:
+                        return "cuckatoo";
+                    case AlgorithmType.DaggerHashimoto:
+                        return "ethash";
+                    default:
+                        return "";
+                }
+            }
+        }
+
+        public NBMiner() : base("nbminer")
+        { }
+
+        protected override int GetMaxCooldownTimeInMilliseconds()
+        {
+            return 60 * 1000;
+        }
+
+        private string GetStartCommand(string url, string btcAddress, string worker)
+        {
+            var user = GetUsername(btcAddress, worker);
+            var devs = string.Join(",", MiningSetup.MiningPairs.Select(p => p.Device.ID));
+            var cmd = $"-a {AlgoName} -o {url} -u {user} --api 127.0.0.1:{ApiPort} -d {devs} ";
+            cmd += ExtraLaunchParametersParser.ParseForMiningSetup(MiningSetup, DeviceType.NVIDIA);
+
+            return cmd;
+        }
+
+        public override void Start(string url, string btcAdress, string worker)
+        {
+            LastCommandLine = GetStartCommand(url, btcAdress, worker);
+
+            ProcessHandle = _Start();
+        }
+
+        protected override void _Stop(MinerStopType willswitch)
+        {
+            ShutdownMiner(true);
+        }
+
+        protected override string BenchmarkCreateCommandLine(Algorithm algorithm, int time)
+        {
+            throw new NotImplementedException();
+        }
+
+        protected override void BenchmarkOutputErrorDataReceivedImpl(string outdata)
+        {
+            throw new NotImplementedException();
+        }
+
+        protected override bool BenchmarkParseLine(string outdata)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override async Task<ApiData> GetSummaryAsync()
+        {
+            return null;
+        }
+    }
+}

--- a/src/NiceHashMinerLegacy/Miners/NBMiner.cs
+++ b/src/NiceHashMinerLegacy/Miners/NBMiner.cs
@@ -1,15 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using NiceHashMiner.Algorithms;
+﻿using NiceHashMiner.Algorithms;
 using NiceHashMiner.Miners.Parsing;
 using NiceHashMinerLegacy.Common.Enums;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
 
 namespace NiceHashMiner.Miners
 {
-    public class NBMiner : Miner
+    public class NBMiner : VanillaProcessMiner
     {
         private string AlgoName
         {
@@ -51,12 +49,7 @@ namespace NiceHashMiner.Miners
         {
             LastCommandLine = GetStartCommand(url, btcAdress, worker);
 
-            ProcessHandle = _Start();
-        }
-
-        protected override void _Stop(MinerStopType willswitch)
-        {
-            ShutdownMiner(true);
+            _Start();
         }
 
         protected override string BenchmarkCreateCommandLine(Algorithm algorithm, int time)

--- a/src/NiceHashMinerLegacy/Miners/NBMiner.cs
+++ b/src/NiceHashMinerLegacy/Miners/NBMiner.cs
@@ -52,6 +52,11 @@ namespace NiceHashMiner.Miners
             _Start();
         }
 
+        protected override void _Stop(MinerStopType willswitch)
+        {
+            KillProspectorClaymoreMinerBase(MinerExeName.Replace(".exe", ""));
+        }
+
         protected override string BenchmarkCreateCommandLine(Algorithm algorithm, int time)
         {
             throw new NotImplementedException();

--- a/src/NiceHashMinerLegacy/Miners/NBMiner.cs
+++ b/src/NiceHashMinerLegacy/Miners/NBMiner.cs
@@ -83,7 +83,7 @@ namespace NiceHashMiner.Miners
         {
             var user = GetUsername(btcAddress, worker);
             var devs = string.Join(",", MiningSetup.MiningPairs.Select(p => p.Device.IDByBus));
-            var cmd = $"-a {AlgoName} -o {url} -u {user} --api 127.0.0.1:{ApiPort} -d {devs} ";
+            var cmd = $"-a {AlgoName} -o {url} -u {user} --api 127.0.0.1:{ApiPort} -d {devs} -RUN ";
             cmd += ExtraLaunchParametersParser.ParseForMiningSetup(MiningSetup, DeviceType.NVIDIA);
 
             return cmd;
@@ -94,11 +94,6 @@ namespace NiceHashMiner.Miners
             LastCommandLine = GetStartCommand(url, btcAdress, worker);
 
             _Start();
-        }
-
-        protected override void _Stop(MinerStopType willswitch)
-        {
-            KillProspectorClaymoreMinerBase(MinerExeName.Replace(".exe", ""));
         }
 
         protected override string BenchmarkCreateCommandLine(Algorithm algorithm, int time)
@@ -112,11 +107,6 @@ namespace NiceHashMiner.Miners
             var worker = ConfigManager.GeneralConfig.WorkerName.Trim();
 
             return GetStartCommand(url, btc, worker);
-        }
-
-        public override void InvokeBenchmarkSignalQuit()
-        {
-            _Stop(MinerStopType.END);
         }
 
         protected override void BenchmarkOutputErrorDataReceivedImpl(string outdata)
@@ -145,8 +135,6 @@ namespace NiceHashMiner.Miners
             {
                 BenchmarkAlgorithm.BenchmarkSpeed = (_benchHashes / _benchIters) * (1 - DevFee * 0.01);
             }
-
-            _Stop(MinerStopType.END);
         }
 
         public override Task<ApiData> GetSummaryAsync()

--- a/src/NiceHashMinerLegacy/Miners/NBMiner.cs
+++ b/src/NiceHashMinerLegacy/Miners/NBMiner.cs
@@ -82,7 +82,7 @@ namespace NiceHashMiner.Miners
         private string GetStartCommand(string url, string btcAddress, string worker)
         {
             var user = GetUsername(btcAddress, worker);
-            var devs = string.Join(",", MiningSetup.MiningPairs.Select(p => p.Device.ID));
+            var devs = string.Join(",", MiningSetup.MiningPairs.Select(p => p.Device.IDByBus));
             var cmd = $"-a {AlgoName} -o {url} -u {user} --api 127.0.0.1:{ApiPort} -d {devs} ";
             cmd += ExtraLaunchParametersParser.ParseForMiningSetup(MiningSetup, DeviceType.NVIDIA);
 
@@ -126,7 +126,7 @@ namespace NiceHashMiner.Miners
 
         protected override bool BenchmarkParseLine(string outdata)
         {
-            var id = MiningSetup.MiningPairs.First().Device.ID;
+            var id = MiningSetup.MiningPairs.First().Device.IDByBus;
             if (!outdata.TryGetHashrateAfter($" - {id}: ", out var hashrate) ||
                 hashrate <= 0)
             {

--- a/src/NiceHashMinerLegacy/Miners/NBMiner.cs
+++ b/src/NiceHashMinerLegacy/Miners/NBMiner.cs
@@ -2,13 +2,38 @@
 using NiceHashMiner.Miners.Parsing;
 using NiceHashMinerLegacy.Common.Enums;
 using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Net.Http;
 using System.Threading.Tasks;
+using Newtonsoft.Json;
+using NiceHashMiner.Interfaces;
 
 namespace NiceHashMiner.Miners
 {
     public class NBMiner : VanillaProcessMiner
     {
+        private class JsonModel : IApiResult
+        {
+            public class MinerModel
+            {
+                public class DeviceModel
+                {
+                    public double hashrate { get; set; }
+                }
+
+                public List<DeviceModel> devices { get; set; }
+
+                public double total_hashrate { get; set; }
+            }
+
+            public MinerModel miner { get; set; }
+
+            public double? TotalHashrate => miner?.total_hashrate;
+        }
+
+        private readonly HttpClient _http = new HttpClient();
+
         private string AlgoName
         {
             get
@@ -72,9 +97,9 @@ namespace NiceHashMiner.Miners
             throw new NotImplementedException();
         }
 
-        public override async Task<ApiData> GetSummaryAsync()
+        public override Task<ApiData> GetSummaryAsync()
         {
-            return null;
+            return GetHttpSummaryAsync<JsonModel>("api/v1/status");
         }
     }
 }

--- a/src/NiceHashMinerLegacy/Miners/VanillaProcessMiner.cs
+++ b/src/NiceHashMinerLegacy/Miners/VanillaProcessMiner.cs
@@ -88,7 +88,10 @@ namespace NiceHashMiner.Miners
             {
                 _process.Kill();
             }
-            catch { }
+            catch (Exception e)
+            {
+                Helpers.ConsolePrint(MinerTag(), e.Message);
+            }
 
             _process.Close();
             _process = null;

--- a/src/NiceHashMinerLegacy/Miners/VanillaProcessMiner.cs
+++ b/src/NiceHashMinerLegacy/Miners/VanillaProcessMiner.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NiceHashMiner.Configs;
+using NiceHashMinerLegacy.Common.Enums;
+
+namespace NiceHashMiner.Miners
+{
+    public abstract class VanillaProcessMiner : Miner
+    {
+        private Process _process;
+
+        protected VanillaProcessMiner(string minerDeviceName) : base(minerDeviceName)
+        { }
+
+        // BMiner throws a fit if started with NiceHashProcess so use System.Diagnostics.Process instead
+        // WARNING ProcessHandle will be null so do not call methods that access it (currently _Stop() is the only
+        // one and it is overridden here)
+        // TODO is NiceHashProcess necessary or can we use System.Diagnostics.Process everywhere?
+        protected override NiceHashProcess _Start(IReadOnlyDictionary<string, string> envVariables = null)
+        {
+            if (_isEnded)
+            {
+                return null;
+            }
+
+            _process = new Process();
+
+            Ethlargement.CheckAndStart(MiningSetup);
+
+            var nhmlDirectory = Directory.GetCurrentDirectory();
+            _process.StartInfo.WorkingDirectory = System.IO.Path.Combine(nhmlDirectory, WorkingDirectory);
+            _process.StartInfo.FileName = System.IO.Path.Combine(nhmlDirectory, Path);
+            _process.StartInfo.Arguments = LastCommandLine;
+            _process.Exited += (sender, args) =>
+            {
+                Miner_Exited();
+            };
+            _process.EnableRaisingEvents = true;
+            _process.StartInfo.CreateNoWindow = ConfigManager.GeneralConfig.HideMiningWindows;
+
+            _process.StartInfo.UseShellExecute = false;
+
+            try
+            {
+                if (_process.Start())
+                {
+                    IsRunning = true;
+
+                    _currentPidData = new MinerPidData
+                    {
+                        MinerBinPath = Path,
+                        Pid = _process.Id
+                    };
+                    _allPidData.Add(_currentPidData);
+
+                    Helpers.ConsolePrint(MinerTag(), "Starting miner " + ProcessTag() + " " + LastCommandLine);
+
+                    StartCoolDownTimerChecker();
+                }
+                else
+                {
+                    Helpers.ConsolePrint(MinerTag(), "NOT STARTED " + ProcessTag() + " " + LastCommandLine);
+                }
+            }
+            catch (Exception ex)
+            {
+                Helpers.ConsolePrint(MinerTag(), ProcessTag() + " _Start: " + ex.Message);
+            }
+
+            return null;
+        }
+
+        protected override void _Stop(MinerStopType willswitch)
+        {
+            if (IsRunning)
+            {
+                Helpers.ConsolePrint(MinerTag(), ProcessTag() + " Shutting down miner");
+            }
+
+            if (_process == null) return;
+
+            try
+            {
+                _process.Kill();
+            }
+            catch { }
+
+            _process.Close();
+            _process = null;
+        }
+    }
+}

--- a/src/NiceHashMinerLegacy/NiceHashMinerLegacy.csproj
+++ b/src/NiceHashMinerLegacy/NiceHashMinerLegacy.csproj
@@ -172,6 +172,7 @@
     <Compile Include="Miners\Phoenix.cs" />
     <Compile Include="Miners\Trex.cs" />
     <Compile Include="Miners\Ttminer.cs" />
+    <Compile Include="Miners\VanillaProcessMiner.cs" />
     <Compile Include="Miners\XmrStak\Configs\XmrStakConfigCpu.cs" />
     <Compile Include="Miners\XmrStak\Configs\XmrStakConfigGpu.cs" />
     <Compile Include="PInvoke\DeviceDetection.cs" />

--- a/src/NiceHashMinerLegacy/NiceHashMinerLegacy.csproj
+++ b/src/NiceHashMinerLegacy/NiceHashMinerLegacy.csproj
@@ -163,6 +163,7 @@
     <Compile Include="Forms\Form_DcriValues.Designer.cs">
       <DependentUpon>Form_DcriValues.cs</DependentUpon>
     </Compile>
+    <Compile Include="Interfaces\IApiResult.cs" />
     <Compile Include="Interfaces\IBenchmarkForm.cs" />
     <Compile Include="Miners\BMiner.cs" />
     <Compile Include="Miners\Equihash\Ewbf144.cs" />

--- a/src/NiceHashMinerLegacy/NiceHashMinerLegacy.csproj
+++ b/src/NiceHashMinerLegacy/NiceHashMinerLegacy.csproj
@@ -168,6 +168,7 @@
     <Compile Include="Miners\Equihash\Ewbf144.cs" />
     <Compile Include="Miners\Ethlargement.cs" />
     <Compile Include="Miners\GMiner.cs" />
+    <Compile Include="Miners\NBMiner.cs" />
     <Compile Include="Miners\Phoenix.cs" />
     <Compile Include="Miners\Trex.cs" />
     <Compile Include="Miners\Ttminer.cs" />

--- a/src/Tests/NiceHashMinerLegacy.Extensions.Tests/StringTest.cs
+++ b/src/Tests/NiceHashMinerLegacy.Extensions.Tests/StringTest.cs
@@ -30,14 +30,25 @@ namespace NiceHashMinerLegacy.Extensions.Tests
             "14:39:00 GPU[1]: 2.442 MH/s  CClk:1.670 GHz MClk:3.802 GHz 70C 100% [A2:R0 0.0%]  LastShare: 00:01:26"
                 .TryGetHashrateAfter("]:", out hash);
             Assert.AreEqual(2442000, hash);
+
+            // NBMiner
+            "[13:11:57] INFO - cuckatoo - 1: 1.47 g/s".TryGetHashrateAfter(" - 1: ", out hash);
+            Assert.AreEqual(1.47, hash);
         }
 
         [TestMethod]
-        public void GetHashrateAfterShouldReturnNull()
+        public void GetHashrateAfterShouldReturnZero()
         {
             Assert.IsFalse("[2019-01-06 21:18:33] : Benchmark Total: --- H/S"
                 .TryGetHashrateAfter("Benchmark Total:", out var hash));
             Assert.AreEqual(0, hash);
+        }
+
+        [TestMethod]
+        public void GetStringAfterShouldExcludeAfter()
+        {
+            var after = "[13:11:57] INFO - cuckatoo - 1: 1.47 g/s".GetStringAfter(" - 1: ");
+            Assert.AreEqual("1.47 g/s", after);
         }
     }
 }


### PR DESCRIPTION
Implements [NBMiner](https://github.com/NebuTech/NBMiner) for grin29 and grin31 on NVIDIA. 

NHML expects NBMiner to be at `bin_3rdparty\nbminer\nbminer.exe`. 

Some other advancements in this branch:

* Beginning of phasing out `NiceHashProcess`
  * `VanillaProcessMiner` inherits `Miner` and uses `System.Diagnostics.Process` instead. Currently `NBMiner` and `BMiner` inherit from this class. 
  * Once we go through and change all miners to use `System.Diagnostics.Process`, `VanillaProcessMiner` can be removed and used as the default logic for `Miner`
  * Benchmark process behaviour is unchanged (it already uses `System.Diagnostics.Process`)
* Add an HTTP REST helper for miner APIs, reduces code duplication for miners that use this method
* Add TTMiner to 3rd party list (we should probably move this list, doesn't make sense to have it on `ComputeDevice`