### PR TITLE
rig id generator use more multiple deterministic sources

### DIFF
--- a/NiceHashMiner.sln
+++ b/NiceHashMiner.sln
@@ -108,6 +108,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ExamplePlugin", "src\Miners
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "runnhmasadmin", "src\Tools\runnhmasadmin\runnhmasadmin.csproj", "{3712894A-0836-4CE3-A4A9-C21A32AACBEC}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RigIDPrinter", "src\Tools\RigIDPrinter\RigIDPrinter.csproj", "{138E97ED-8C5B-4C31-90F8-4260714A56E7}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -840,6 +842,22 @@ Global
 		{3712894A-0836-4CE3-A4A9-C21A32AACBEC}.Release|Win32.Build.0 = Release|Any CPU
 		{3712894A-0836-4CE3-A4A9-C21A32AACBEC}.Release|x64.ActiveCfg = Release|Any CPU
 		{3712894A-0836-4CE3-A4A9-C21A32AACBEC}.Release|x64.Build.0 = Release|Any CPU
+		{138E97ED-8C5B-4C31-90F8-4260714A56E7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{138E97ED-8C5B-4C31-90F8-4260714A56E7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{138E97ED-8C5B-4C31-90F8-4260714A56E7}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{138E97ED-8C5B-4C31-90F8-4260714A56E7}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{138E97ED-8C5B-4C31-90F8-4260714A56E7}.Debug|Win32.ActiveCfg = Debug|Any CPU
+		{138E97ED-8C5B-4C31-90F8-4260714A56E7}.Debug|Win32.Build.0 = Debug|Any CPU
+		{138E97ED-8C5B-4C31-90F8-4260714A56E7}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{138E97ED-8C5B-4C31-90F8-4260714A56E7}.Debug|x64.Build.0 = Debug|Any CPU
+		{138E97ED-8C5B-4C31-90F8-4260714A56E7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{138E97ED-8C5B-4C31-90F8-4260714A56E7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{138E97ED-8C5B-4C31-90F8-4260714A56E7}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{138E97ED-8C5B-4C31-90F8-4260714A56E7}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{138E97ED-8C5B-4C31-90F8-4260714A56E7}.Release|Win32.ActiveCfg = Release|Any CPU
+		{138E97ED-8C5B-4C31-90F8-4260714A56E7}.Release|Win32.Build.0 = Release|Any CPU
+		{138E97ED-8C5B-4C31-90F8-4260714A56E7}.Release|x64.ActiveCfg = Release|Any CPU
+		{138E97ED-8C5B-4C31-90F8-4260714A56E7}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -885,6 +903,7 @@ Global
 		{FA68227D-27A2-4058-8D36-005FADAFECC0} = {F40126B4-5B3B-4085-B47D-A5EF4B51570C}
 		{DFC88036-796A-4046-B3B6-DE9FA56EDF28} = {F40126B4-5B3B-4085-B47D-A5EF4B51570C}
 		{3712894A-0836-4CE3-A4A9-C21A32AACBEC} = {BB931C9A-EE48-42A6-B5F3-3A193B1A051A}
+		{138E97ED-8C5B-4C31-90F8-4260714A56E7} = {BB931C9A-EE48-42A6-B5F3-3A193B1A051A}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {6E8897DC-99C6-4585-A2BA-CB194F3B1AB7}

--- a/src/NHM.Common/Logger.cs
+++ b/src/NHM.Common/Logger.cs
@@ -29,7 +29,6 @@ namespace NHM.Common
 
         private static void LogGroupTextType(string grp, string text, LogType type)
         {
-            if (!_isInitSucceess) return;
             // Console.WriteLine does nothing on x64 while debugging with VS, so use Debug. Console.WriteLine works when run from .exe
             var fallbackLogLine = $"[{DateTime.Now.ToLongTimeString()}] [{grp}] {text}";
 #if DEBUG
@@ -39,7 +38,7 @@ namespace NHM.Common
             Console.WriteLine(fallbackLogLine);
 #endif
 
-
+            if (!_isInitSucceess) return;
             if (!Enabled) return;
             // try will prevent an error if something tries to print an invalid character
             try

--- a/src/NHM.UUID/WindowsMacUtils.cs
+++ b/src/NHM.UUID/WindowsMacUtils.cs
@@ -1,0 +1,38 @@
+﻿using NHM.Common;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NHM.UUID
+{
+    public static class WindowsMacUtils
+    {
+        [DllImport("rpcrt4.dll", SetLastError = true)]
+        private static extern int UuidCreateSequential(out System.Guid guid);
+
+        private const long RPC_S_OK = 0L;
+        private const long RPC_S_UUID_LOCAL_ONLY = 1824L;
+        private const long RPC_S_UUID_NO_ADDRESS = 1739L;
+
+        public static string GetMAC_UUID()
+        {
+            try
+            {
+                System.Guid guid;
+                UuidCreateSequential(out guid);
+                var splitted = guid.ToString().Split('-');
+                var last = splitted.LastOrDefault();
+                if (last != null) return last;
+            }
+            catch (Exception e)
+            {
+                Logger.Error("NHM.UUID", $"WindowsMacUtils.GetMAC_UUID: {e.Message}");
+            }
+            Logger.Warn("NHM.UUID", $"WindowsMacUtils.GetMAC_UUID FALLBACK");
+            return System.Guid.NewGuid().ToString();
+        }
+    }
+}

--- a/src/NiceHashMiner/ApplicationStateManager/ApplicationStateManager.cs
+++ b/src/NiceHashMiner/ApplicationStateManager/ApplicationStateManager.cs
@@ -18,7 +18,7 @@ namespace NiceHashMiner
 {
     static partial class ApplicationStateManager
     {
-        public static string RigID => UUID.GetDeviceB64UUID();
+        public static string RigID { get; } = UUID.GetDeviceB64UUID();
 
         // change this if TOS changes
         public static int CurrentTosVer => 4;

--- a/src/NiceHashMiner/Configs/ConfigManager.cs
+++ b/src/NiceHashMiner/Configs/ConfigManager.cs
@@ -77,7 +77,7 @@ namespace NiceHashMiner.Configs
             TryMigrate();
             // init defaults
             GeneralConfig.SetDefaults();
-            GeneralConfig.hwid = SystemSpecs.GetCpuID();
+            GeneralConfig.hwid = ApplicationStateManager.RigID;
             // load file if it exist
             var fromFile = InternalConfigs.ReadFileSettings<GeneralConfig>(GeneralConfigPath);
             if (fromFile != null)

--- a/src/NiceHashMiner/Utils/SystemSpecs.cs
+++ b/src/NiceHashMiner/Utils/SystemSpecs.cs
@@ -104,24 +104,6 @@ namespace NiceHashMiner.Utils
             }
         }
 
-        public static string GetCpuID()
-        {
-            var serial = "N/A";
-            try
-            {
-                using (var searcher = new ManagementObjectSearcher("Select ProcessorID from Win32_processor"))
-                using (var query = searcher.Get())
-                {
-                    foreach (var item in query)
-                    {
-                        serial = item.GetPropertyValue("ProcessorID").ToString();
-                    }
-                }
-            }
-            catch { }
-            return serial;
-        }
-
         public static bool IsWmiEnabled()
         {
             try

--- a/src/Tools/RigIDPrinter/App.config
+++ b/src/Tools/RigIDPrinter/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+    </startup>
+</configuration>

--- a/src/Tools/RigIDPrinter/Program.cs
+++ b/src/Tools/RigIDPrinter/Program.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace RigIDPrinter
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            var rigId = NHM.UUID.UUID.GetDeviceB64UUID(true);
+            Console.WriteLine($"RIG_ID: {rigId}");
+        }
+    }
+}

--- a/src/Tools/RigIDPrinter/Properties/AssemblyInfo.cs
+++ b/src/Tools/RigIDPrinter/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("RigIDPrinter")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("RigIDPrinter")]
+[assembly: AssemblyCopyright("Copyright ©  2019")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("138e97ed-8c5b-4c31-90f8-4260714a56e7")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/Tools/RigIDPrinter/RigIDPrinter.csproj
+++ b/src/Tools/RigIDPrinter/RigIDPrinter.csproj
@@ -4,39 +4,38 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{EE6160CC-8C19-4AD8-BB1E-C295347203EE}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>NHM.UUID</RootNamespace>
-    <AssemblyName>NHM.UUID</AssemblyName>
+    <ProjectGuid>{138E97ED-8C5B-4C31-90F8-4260714A56E7}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>RigIDPrinter</RootNamespace>
+    <AssemblyName>RigIDPrinter</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>x64</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
+    <OutputPath>..\..\..\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
+    <OutputPath>..\..\..\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="BouncyCastle.Crypto, Version=1.8.5.0, Culture=neutral, PublicKeyToken=0e99375e54769942">
-      <HintPath>..\..\packages\BouncyCastle.1.8.5\lib\BouncyCastle.Crypto.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Management" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -45,21 +44,16 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="3rdParty\Guid\Constants.cs" />
-    <Compile Include="3rdParty\Guid\Providers\HashProvider.cs" />
-    <Compile Include="3rdParty\Guid\Providers\RandomNumberProvider.cs" />
-    <Compile Include="3rdParty\Guid\UUID.cs" />
-    <Compile Include="UUID.cs" />
+    <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="WindowsMacUtils.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
+    <None Include="App.config" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\NHM.Common\NHM.Common.csproj">
-      <Project>{279a5b29-3799-43fa-9734-e462e046ba81}</Project>
-      <Name>NHM.Common</Name>
+    <ProjectReference Include="..\..\NHM.UUID\NHM.UUID.csproj">
+      <Project>{ee6160cc-8c19-4ad8-bb1e-c295347203ee}</Project>
+      <Name>NHM.UUID</Name>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />


### PR DESCRIPTION
This PR makes the RigUUID generation more robust to OS cloning. It also has an additional user fallback seed. 

data inputs:
`NHM/[{cpuSerial}]-[{macUUID}]-[{guid}]-[{extraRigSeed}]`