### PR TITLE
Make the Vega detection additionally work for cards without Vega in the name

### DIFF
--- a/src/Miners/MinerPluginToolkitV1/Checkers.cs
+++ b/src/Miners/MinerPluginToolkitV1/Checkers.cs
@@ -14,7 +14,7 @@ namespace MinerPluginToolkitV1
         /// </summary>
         public static bool IsGcn4(AMDDevice dev)
         {
-            if (dev.Name.Contains("Vega"))
+            if (dev.Name.Contains("Vega")  || dev.InfSection.ToLower().Contains("r7500") || dev.InfSection.ToLower().Contains("vega"))
                 return true;
             if (dev.InfSection.ToLower().Contains("polaris"))
                 return true;
@@ -27,7 +27,7 @@ namespace MinerPluginToolkitV1
         /// </summary>
         public static bool IsGcn2(AMDDevice dev)
         {
-            if (dev.Name.Contains("Vega"))
+            if (dev.Name.Contains("Vega") || dev.InfSection.ToLower().Contains("r7500") || dev.InfSection.ToLower().Contains("vega"))
                 return true;
             if (!dev.InfSection.ToLower().Contains("pitcairn ") && !dev.InfSection.ToLower().Contains("tahiti") && !dev.InfSection.ToLower().Contains("oland") && !dev.InfSection.ToLower().Contains("cape verde"))
                 return true;


### PR DESCRIPTION
This affects WX, Instinct, Radeon VII.

Nicehash should probably use a more robust detection eventually.