### PR TITLE
fix: "NHM experienced too many crashes, ..."

### DIFF
--- a/src/NiceHashMinerLauncher/App.xaml.cs
+++ b/src/NiceHashMinerLauncher/App.xaml.cs
@@ -357,7 +357,6 @@ namespace NiceHashMiner
                                         sw.WriteLine($"Too many restarts! Closing nhm");
                                     }
                                     MessageBox.Show("NHM experienced too many crashes recently, therefore it will close itself", "Too many restarts");
-                                    run = false;
                                 }
                             }
                             else


### PR DESCRIPTION
Quick fix of:
```
---------------------------
Too many restarts
---------------------------
NHM experienced too many crashes recently, therefore it will close itself
---------------------------
OK   
---------------------------
```

This issue is not completely fixed with this PR. This just helps using the app again after too many crashes. This still needs a proper fix!

Issues linked to this: #2327

