### PR TITLE
Remove benchmark duration overrides for Excavator

### DIFF
--- a/src/Miners/Excavator/PluginInternalSettings.cs
+++ b/src/Miners/Excavator/PluginInternalSettings.cs
@@ -12,15 +12,6 @@ namespace Excavator
 
         internal static MinerApiMaxTimeoutSetting GetApiMaxTimeoutConfig { get; set; } = new MinerApiMaxTimeoutSetting { GeneralTimeout = DefaultTimeout };
 
-        internal static MinerBenchmarkTimeSettings BenchmarkTimeSettings = new MinerBenchmarkTimeSettings
-        {
-            General = new Dictionary<BenchmarkPerformanceType, int> {
-                { BenchmarkPerformanceType.Quick,    20  },
-                { BenchmarkPerformanceType.Standard, 40  },
-                { BenchmarkPerformanceType.Precise,  60  },
-            },
-        };
-
         internal static MinerOptionsPackage MinerOptionsPackage = new MinerOptionsPackage
         {
             GeneralOptions = new List<MinerOption>


### PR DESCRIPTION
The benchmark timing overrides for Excavator make it the shortest and least accurate DaggerHashimoto benchmarks.
By using the default benchmark durations, my "precise" benchmarks went from 10 MH/s to 27 MH/s.