### PR TITLE
Make restart delay only apply to restarts

### DIFF
--- a/src/NHMCore/Mining/Miner.cs
+++ b/src/NHMCore/Mining/Miner.cs
@@ -314,8 +314,8 @@ namespace NHMCore.Mining
                             {
                                 Logger.Info(MinerTag(), $"Restart Mining in {MiningSettings.Instance.MinerRestartDelayMS}ms");
                                 AvailableNotifications.CreateRestartedMinerInfo(DateTime.UtcNow.ToLocalTime(), _plugin.Name);
+                                await TaskHelpers.TryDelay(MiningSettings.Instance.MinerRestartDelayMS, linkedEndMiner.Token);
                             }
-                            await TaskHelpers.TryDelay(MiningSettings.Instance.MinerRestartDelayMS, linkedEndMiner.Token);
                             var result = await StartAsync(linkedEndMiner.Token, miningLocation, username);
                             if (firstStart)
                             {


### PR DESCRIPTION
Fixes #2590 so that the restart delay only applies to restarts, not the initial miner launch