### PR TITLE
trex api-bind-telnet incompatibility

### DIFF
--- a/src/Miners/TRex/TRex.cs
+++ b/src/Miners/TRex/TRex.cs
@@ -81,7 +81,7 @@ namespace TRex
             }
             var algo = AlgorithmName(_algorithmType);
 
-            var commandLine = $"--algo {algo} --url {url} --user {_username} --api-bind-http 127.0.0.1:{_apiPort} --api-bind-telnet 0 --devices {_devices} {_extraLaunchParameters} --no-watchdog";
+            var commandLine = $"--algo {algo} --url {url} --user {_username} --api-bind-http 127.0.0.1:{_apiPort} --devices {_devices} {_extraLaunchParameters} --no-watchdog";
             return commandLine;
         }
     }


### PR DESCRIPTION
I already know you don't support unassigned binaries, but at least let us use newer trex versions, with out this change that's no possible.

 This command "--api-bind-telnet 0" breaks compatibility with newer versions, and if you remove it doesn't break older versions.