### PR TITLE
fixed Improper Limitation of a Pathname to a Restricted Directory an arbitrary file access during archive extraction on MinerLauncher

### DIFF
--- a/src/NiceHashMinerLauncher/App.xaml.cs
+++ b/src/NiceHashMinerLauncher/App.xaml.cs
@@ -512,11 +512,17 @@ namespace NiceHashMiner
                     var prog = ((extractedEntries / entriesCount) * 100.0f);
                     progress?.Report((int)prog);
 
-                    var extractPath = Path.Combine(unzipLocation, entry.FullName);
+                    var rawExtractPath = Path.Combine(unzipLocation, entry.FullName);
+                    var extractPath = Path.GetFullPath(rawExtractPath);
+                    var fullUnzipLocation = Path.GetFullPath(unzipLocation + Path.DirectorySeparatorChar);
+                    if (!extractPath.StartsWith(fullUnzipLocation, StringComparison.Ordinal))
+                    {
+                        throw new InvalidOperationException($"Entry is outside the target dir: {extractPath}");
+                    }
                     var dirPath = Path.GetDirectoryName(extractPath);
                     if (!Directory.Exists(dirPath))
                     {
-                        Directory.CreateDirectory(Path.GetDirectoryName(extractPath));
+                        Directory.CreateDirectory(dirPath);
                     }
                     //entry.ExtractToFile(extractPath, true);
 


### PR DESCRIPTION
https://github.com/nicehash/NiceHashMiner/blob/b01b6c9f102fd898fb68345cdc7331240265c062/src/NiceHashMinerLauncher/App.xaml.cs#L515-L515

https://github.com/nicehash/NiceHashMiner/blob/b01b6c9f102fd898fb68345cdc7331240265c062/src/NiceHashMinerLauncher/App.xaml.cs#L519-L519

Extracting files from a malicious zip file, or similar type of archive, is at risk of directory traversal attacks if filenames from the archive are not properly validated. zip archives contain archive entries representing each file in the archive. These entries include a file path for the entry, but these file paths are not restricted and may contain unexpected special elements such as the directory traversal element (..). If these file paths are used to create a filesystem path, then a file operation may happen in an unexpected location. This can result in sensitive information being revealed or deleted, or an attacker being able to influence behavior by modifying unexpected files.



fix the Zip Slip vulnerability, we need to ensure that files extracted from the archive cannot escape the intended extraction directory. This involves three steps:

1. **Sanitize the output path:** Use `Path.GetFullPath` on the combined path to resolve any directory traversal elements.
2. **Resolve the extraction directory:** Use `Path.GetFullPath` on the extraction directory (with a trailing separator) to get its canonical form.
3. **Validate the output path:** Ensure that the sanitized output path starts with the canonical extraction directory path. If not, skip extraction or throw an exception.

These changes should be made in the method that performs the extraction, specifically around the lines where `extractPath` is constructed and used. No changes to existing functionality are required, except for aborting extraction of malicious entries. The required methods (`Path.GetFullPath`, `StartsWith`) are already available in the imported libraries.